### PR TITLE
Add `file_open` policy

### DIFF
--- a/guardity-common/Cargo.toml
+++ b/guardity-common/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 
 [features]
 default = []
-user = ["aya"]
+user = ["anyhow", "aya"]
 
 [dependencies]
+anyhow = { version = "1.0", optional = true }
 aya = { version = ">=0.11", optional = true }
 
 [lib]

--- a/guardity-common/src/lib.rs
+++ b/guardity-common/src/lib.rs
@@ -1,1 +1,19 @@
 #![no_std]
+
+pub const MAX_PATHS: usize = 8;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Paths {
+    pub all: bool,
+    pub len: usize,
+    pub paths: [u64; MAX_PATHS],
+    pub _padding: [u8; 7],
+}
+
+#[cfg(feature = "user")]
+pub mod user {
+    use super::*;
+
+    unsafe impl aya::Pod for Paths {}
+}

--- a/guardity-ebpf/Cargo.toml
+++ b/guardity-ebpf/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 
 [profile.dev]
 opt-level = 3
-debug = false
 debug-assertions = false
 overflow-checks = false
 lto = true

--- a/guardity/src/main.rs
+++ b/guardity/src/main.rs
@@ -49,12 +49,12 @@ async fn main() -> Result<(), anyhow::Error> {
         warn!("failed to initialize eBPF logger: {}", e);
     }
     let btf = Btf::from_sys_fs()?;
-    let program: &mut Lsm = bpf.program_mut("task_fix_setuid").unwrap().try_into()?;
-    program.load("task_fix_setuid", &btf)?;
-    program.attach()?;
-    let program: &mut Lsm = bpf.program_mut("socket_recvmsg").unwrap().try_into()?;
-    program.load("socket_recvmsg", &btf)?;
-    program.attach()?;
+    let programs = vec!["file_open", "task_fix_setuid", "socket_recvmsg"];
+    for name in programs {
+        let program: &mut Lsm = bpf.program_mut(name).unwrap().try_into()?;
+        program.load(name, &btf)?;
+        program.attach()?;
+    }
 
     for p in opt.policy {
         let policies = reader::read_policies(p)?;

--- a/guardity/src/policy/engine.rs
+++ b/guardity/src/policy/engine.rs
@@ -1,4 +1,5 @@
 use aya::{maps::HashMap, Bpf};
+use guardity_common::Paths;
 use log::info;
 
 use super::{Policy, PolicySubject};
@@ -9,6 +10,39 @@ pub const INODE_WILDCARD: u64 = 0;
 pub fn process_policy(bpf: &mut Bpf, policy: Policy) -> anyhow::Result<()> {
     info!("Processing policy: {:?}", policy);
     match policy {
+        Policy::FileOpen {
+            subject,
+            allow,
+            deny,
+        } => {
+            let allow: Paths = allow.into();
+            let deny: Paths = deny.into();
+            match subject {
+                PolicySubject::Process(path) => {
+                    let bin_inode = fs::inode(path)?;
+
+                    let mut allowed_file_open: HashMap<_, u64, Paths> =
+                        bpf.map_mut("ALLOWED_FILE_OPEN").unwrap().try_into()?;
+                    allowed_file_open.insert(bin_inode, allow, 0)?;
+
+                    let mut denied_file_open: HashMap<_, u64, Paths> =
+                        bpf.map_mut("DENIED_FILE_OPEN").unwrap().try_into()?;
+                    denied_file_open.insert(bin_inode, deny, 0)?;
+                }
+                PolicySubject::Container(_) => {
+                    unimplemented!();
+                }
+                PolicySubject::All => {
+                    let mut allowed_file_open: HashMap<_, u64, Paths> =
+                        bpf.map_mut("ALLOWED_FILE_OPEN").unwrap().try_into()?;
+                    allowed_file_open.insert(INODE_WILDCARD, allow, 0)?;
+
+                    let mut denied_file_open: HashMap<_, u64, Paths> =
+                        bpf.map_mut("DENIED_FILE_OPEN").unwrap().try_into()?;
+                    denied_file_open.insert(INODE_WILDCARD, deny, 0)?;
+                }
+            }
+        }
         Policy::SetUid { subject, allow } => {
             match subject {
                 PolicySubject::Process(path) => {

--- a/policy.yaml
+++ b/policy.yaml
@@ -4,3 +4,8 @@
 - !setuid
   subject: !process /usr/bin/sudo
   allow: true
+- !file_open
+  subject: all
+  allow: all
+  deny: !paths
+    - /home/vadorovsky/forbidden


### PR DESCRIPTION
This system policy is based on `file_open` LSM hook and allows to define lists of paths which are allow- or deny-listed for the given subject (process).