### PR TITLE
ebpf: Split into library and modules

### DIFF
--- a/guardity-common/src/lib.rs
+++ b/guardity-common/src/lib.rs
@@ -1,21 +1,21 @@
 #![no_std]
 
-pub const MAX_PATHS: usize = 8;
-pub const MAX_PORTS: usize = 8;
-pub const MAX_IPV4ADDRS: usize = 8;
-pub const MAX_IPV6ADDRS: usize = 8;
+pub const MAX_PATHS: usize = 1;
+pub const MAX_PORTS: usize = 1;
+pub const MAX_IPV4ADDRS: usize = 1;
+pub const MAX_IPV6ADDRS: usize = 1;
 
 #[repr(C)]
 #[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
-pub struct FileOpenAlert {
+pub struct AlertFileOpen {
     pub pid: u32,
     pub _padding: u32,
     pub binprm_inode: u64,
     pub inode: u64,
 }
 
-impl FileOpenAlert {
+impl AlertFileOpen {
     pub fn new(pid: u32, binprm_inode: u64, inode: u64) -> Self {
         Self {
             pid,
@@ -29,7 +29,7 @@ impl FileOpenAlert {
 #[repr(C)]
 #[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
-pub struct SetuidAlert {
+pub struct AlertSetuid {
     pub pid: u32,
     pub _padding: u32,
     pub binprm_inode: u64,
@@ -39,7 +39,7 @@ pub struct SetuidAlert {
     pub new_gid: u32,
 }
 
-impl SetuidAlert {
+impl AlertSetuid {
     pub fn new(
         pid: u32,
         binprm_inode: u64,
@@ -63,7 +63,7 @@ impl SetuidAlert {
 #[repr(C)]
 #[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
-pub struct SocketBindAlert {
+pub struct AlertSocketBind {
     pub pid: u32,
     pub _padding1: u32,
     pub binprm_inode: u64,
@@ -71,7 +71,7 @@ pub struct SocketBindAlert {
     pub _padding2: [u16; 3],
 }
 
-impl SocketBindAlert {
+impl AlertSocketBind {
     pub fn new(pid: u32, binprm_inode: u64, port: u16) -> Self {
         Self {
             pid,
@@ -225,8 +225,8 @@ pub mod user {
 
     use aya::Pod;
 
-    unsafe impl Pod for FileOpenAlert {}
-    unsafe impl Pod for SetuidAlert {}
+    unsafe impl Pod for AlertFileOpen {}
+    unsafe impl Pod for AlertSetuid {}
     unsafe impl Pod for Paths {}
     unsafe impl Pod for Ports {}
     unsafe impl Pod for Ipv4Addrs {}

--- a/guardity-ebpf/Cargo.toml
+++ b/guardity-ebpf/Cargo.toml
@@ -8,6 +8,10 @@ aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 guardity-common = { path = "../guardity-common" }
 
+[lib]
+name = "guardity_ebpf"
+path = "src/lib.rs"
+
 [[bin]]
 name = "guardity"
 path = "src/main.rs"

--- a/guardity-ebpf/src/binprm.rs
+++ b/guardity-ebpf/src/binprm.rs
@@ -2,6 +2,15 @@ use aya_bpf::helpers::bpf_get_current_task_btf;
 
 use crate::vmlinux::task_struct;
 
+/// Returns the inode of the current binary.
+///
+/// # Examples
+///
+/// ```rust
+/// use guardity_ebpf::binprm::current_binprm_inode;
+///
+/// let inode = current_binprm_inode();
+/// ```
 #[inline(always)]
 pub(crate) fn current_binprm_inode() -> u64 {
     let task = unsafe { bpf_get_current_task_btf() as *mut task_struct };

--- a/guardity-ebpf/src/consts.rs
+++ b/guardity-ebpf/src/consts.rs
@@ -1,0 +1,7 @@
+/// Wildcard for the inode.
+pub const INODE_WILDCARD: u64 = 0;
+
+/// IPv4 family.
+pub const AF_INET: u16 = 2;
+/// IPv6 family.
+pub const AF_INET6: u16 = 10;

--- a/guardity-ebpf/src/file_open.rs
+++ b/guardity-ebpf/src/file_open.rs
@@ -1,0 +1,198 @@
+use core::cmp;
+
+use aya_bpf::{cty::c_long, programs::LsmContext, BpfContext};
+use guardity_common::{AlertFileOpen, MAX_PATHS};
+
+use crate::{
+    binprm::current_binprm_inode,
+    consts::INODE_WILDCARD,
+    maps::{ALERT_FILE_OPEN, ALLOWED_FILE_OPEN, DENIED_FILE_OPEN},
+    vmlinux::file,
+};
+
+const MAX_DIR_DEPTH: usize = 16;
+
+/// Inspects the context of `file_open` LSM hook and decides whether to allow or
+/// deny the operation based on the state of the `ALLOWED_FILE_OPEN` and
+/// `DENIED_FILE_OPEN` maps.
+///
+/// If denied, the operation is logged to the `ALERT_FILE_OPEN` map.
+///
+/// # Example
+///
+/// ```rust
+/// use aya_bpf::{macros::lsm, programs::LsmContext};
+/// use guardity_ebpf::file_open;
+///
+/// #[lsm(name = "my_program")]
+/// pub fn my_program(ctx: LsmContext) -> i32 {
+///     match file_open::file_open(ctx) {
+///         Ok(ret) => ret,
+///         Err(_) => 0,
+///     }
+/// }
+/// ```
+pub fn file_open(ctx: LsmContext) -> Result<i32, c_long> {
+    let file: *const file = unsafe { ctx.arg(0) };
+
+    let binprm_inode = current_binprm_inode();
+    let inode = unsafe { (*(*(*file).f_path.dentry).d_inode).i_ino };
+
+    if let Some(paths) = unsafe { ALLOWED_FILE_OPEN.get(&INODE_WILDCARD) } {
+        if paths.all {
+            if let Some(paths) = unsafe { DENIED_FILE_OPEN.get(&INODE_WILDCARD) } {
+                if paths.all {
+                    ALERT_FILE_OPEN.output(
+                        &ctx,
+                        &AlertFileOpen::new(ctx.pid(), binprm_inode, inode),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+
+                let len = cmp::min(paths.len, MAX_PATHS);
+                if paths.paths[..len].contains(&inode) {
+                    ALERT_FILE_OPEN.output(
+                        &ctx,
+                        &AlertFileOpen::new(ctx.pid(), binprm_inode, inode),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+
+                let mut previous_inode = inode;
+                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
+                for _ in 0..MAX_DIR_DEPTH {
+                    if parent_dentry.is_null() {
+                        break;
+                    }
+                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
+                    if inode == previous_inode {
+                        break;
+                    }
+                    let len = cmp::min(paths.len, MAX_PATHS);
+                    if paths.paths[..len].contains(&inode) {
+                        ALERT_FILE_OPEN.output(
+                            &ctx,
+                            &AlertFileOpen::new(ctx.pid(), binprm_inode, inode),
+                            0,
+                        );
+                        return Ok(-1);
+                    }
+                    previous_inode = inode;
+                    parent_dentry = unsafe { (*parent_dentry).d_parent };
+                }
+            }
+
+            if let Some(paths) = unsafe { DENIED_FILE_OPEN.get(&binprm_inode) } {
+                if paths.all {
+                    ALERT_FILE_OPEN.output(
+                        &ctx,
+                        &AlertFileOpen::new(ctx.pid(), binprm_inode, inode),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+
+                let len = cmp::min(paths.len, MAX_PATHS);
+                if paths.paths[..len].contains(&inode) {
+                    ALERT_FILE_OPEN.output(
+                        &ctx,
+                        &AlertFileOpen::new(ctx.pid(), binprm_inode, inode),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+
+                let mut previous_inode = inode;
+                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
+                for _ in 0..MAX_DIR_DEPTH {
+                    if parent_dentry.is_null() {
+                        break;
+                    }
+                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
+                    if inode == previous_inode {
+                        break;
+                    }
+                    let len = cmp::min(paths.len, MAX_PATHS);
+                    if paths.paths[..len].contains(&inode) {
+                        ALERT_FILE_OPEN.output(
+                            &ctx,
+                            &AlertFileOpen::new(ctx.pid(), binprm_inode, inode),
+                            0,
+                        );
+                        return Ok(-1);
+                    }
+                    previous_inode = inode;
+                    parent_dentry = unsafe { (*parent_dentry).d_parent };
+                }
+            }
+        }
+    }
+
+    if let Some(paths) = unsafe { DENIED_FILE_OPEN.get(&INODE_WILDCARD) } {
+        if paths.all {
+            if let Some(paths) = unsafe { ALLOWED_FILE_OPEN.get(&INODE_WILDCARD) } {
+                if paths.all {
+                    return Ok(0);
+                }
+
+                let len = cmp::min(paths.len, MAX_PATHS);
+                if paths.paths[..len].contains(&inode) {
+                    return Ok(0);
+                }
+
+                let mut previous_inode = inode;
+                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
+                for _ in 0..MAX_DIR_DEPTH {
+                    if parent_dentry.is_null() {
+                        break;
+                    }
+                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
+                    if inode == previous_inode {
+                        break;
+                    }
+                    let len = cmp::min(paths.len, MAX_PATHS);
+                    if paths.paths[..len].contains(&inode) {
+                        return Ok(0);
+                    }
+                    previous_inode = inode;
+                    parent_dentry = unsafe { (*parent_dentry).d_parent };
+                }
+            }
+
+            if let Some(paths) = unsafe { ALLOWED_FILE_OPEN.get(&binprm_inode) } {
+                if paths.all {
+                    return Ok(0);
+                }
+
+                let len = cmp::min(paths.len, MAX_PATHS);
+                if paths.paths[..len].contains(&inode) {
+                    return Ok(0);
+                }
+
+                let mut previous_inode = inode;
+                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
+                for _ in 0..MAX_DIR_DEPTH {
+                    if parent_dentry.is_null() {
+                        break;
+                    }
+                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
+                    if inode == previous_inode {
+                        break;
+                    }
+                    let len = cmp::min(paths.len, MAX_PATHS);
+                    if paths.paths[..len].contains(&inode) {
+                        return Ok(0);
+                    }
+                    previous_inode = inode;
+                    parent_dentry = unsafe { (*parent_dentry).d_parent };
+                }
+            }
+            ALERT_FILE_OPEN.output(&ctx, &AlertFileOpen::new(ctx.pid(), binprm_inode, inode), 0);
+            return Ok(-1);
+        }
+    }
+
+    Ok(0)
+}

--- a/guardity-ebpf/src/lib.rs
+++ b/guardity-ebpf/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+pub mod binprm;
+pub mod consts;
+pub mod file_open;
+pub mod maps;
+pub mod setuid;
+pub mod socket_bind;
+pub mod socket_connect;
+#[allow(non_upper_case_globals)]
+#[allow(non_snake_case)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+pub mod vmlinux;

--- a/guardity-ebpf/src/main.rs
+++ b/guardity-ebpf/src/main.rs
@@ -1,290 +1,40 @@
 #![no_std]
 #![no_main]
 
-use core::cmp;
+use aya_bpf::{macros::lsm, programs::LsmContext};
 
-use aya_bpf::{
-    cty::c_long,
-    macros::{lsm, map},
-    maps::{HashMap, PerfEventArray},
-    programs::LsmContext,
-    BpfContext,
+use guardity_ebpf::{
+    file_open::file_open, setuid::task_fix_setuid, socket_bind::socket_bind,
+    socket_connect::socket_connect,
 };
 
-pub(crate) mod binprm;
-pub(crate) mod maps;
-mod socket;
-#[allow(non_upper_case_globals)]
-#[allow(non_snake_case)]
-#[allow(non_camel_case_types)]
-#[allow(dead_code)]
-pub(crate) mod vmlinux;
-
-use binprm::current_binprm_inode;
-use guardity_common::{FileOpenAlert, Paths, SetuidAlert, MAX_PATHS};
-use socket::{try_socket_bind, try_socket_connect};
-use vmlinux::{cred, file};
-
-const INODE_WILDCARD: u64 = 0;
-// const MAX_DIR_DEPTH: usize = 256;
-const MAX_DIR_DEPTH: usize = 16;
-
-#[map]
-static ALLOWED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
-
-#[map]
-static DENIED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
-
-#[map]
-static ALERT_FILE_OPEN: PerfEventArray<FileOpenAlert> = PerfEventArray::pinned(1024, 0);
-
-#[map]
-static ALLOWED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
-
-#[map]
-static DENIED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
-
-#[map]
-static ALERT_SETUID: PerfEventArray<SetuidAlert> = PerfEventArray::pinned(1024, 0);
-
 #[lsm(name = "file_open")]
-pub fn file_open(ctx: LsmContext) -> i32 {
-    match try_file_open(ctx) {
+pub fn prog_file_open(ctx: LsmContext) -> i32 {
+    match file_open(ctx) {
         Ok(ret) => ret,
         Err(_) => 0,
     }
-}
-
-fn try_file_open(ctx: LsmContext) -> Result<i32, c_long> {
-    let file: *const file = unsafe { ctx.arg(0) };
-
-    let binprm_inode = current_binprm_inode();
-    let inode = unsafe { (*(*(*file).f_path.dentry).d_inode).i_ino };
-
-    if let Some(paths) = unsafe { ALLOWED_FILE_OPEN.get(&INODE_WILDCARD) } {
-        if paths.all {
-            if let Some(paths) = unsafe { DENIED_FILE_OPEN.get(&INODE_WILDCARD) } {
-                if paths.all {
-                    ALERT_FILE_OPEN.output(
-                        &ctx,
-                        &FileOpenAlert::new(ctx.pid(), binprm_inode, inode),
-                        0,
-                    );
-                    return Ok(-1);
-                }
-
-                for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                    if paths.paths[i] == inode {
-                        ALERT_FILE_OPEN.output(
-                            &ctx,
-                            &FileOpenAlert::new(ctx.pid(), binprm_inode, inode),
-                            0,
-                        );
-                        return Ok(-1);
-                    }
-                }
-
-                let mut previous_inode = inode;
-                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
-                for _ in 0..MAX_DIR_DEPTH {
-                    if parent_dentry.is_null() {
-                        break;
-                    }
-                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
-                    if inode == previous_inode {
-                        break;
-                    }
-                    for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                        if paths.paths[i] == inode {
-                            ALERT_FILE_OPEN.output(
-                                &ctx,
-                                &FileOpenAlert::new(ctx.pid(), binprm_inode, inode),
-                                0,
-                            );
-                            return Ok(-1);
-                        }
-                    }
-                    previous_inode = inode;
-                    parent_dentry = unsafe { (*parent_dentry).d_parent };
-                }
-            }
-
-            if let Some(paths) = unsafe { DENIED_FILE_OPEN.get(&binprm_inode) } {
-                if paths.all {
-                    ALERT_FILE_OPEN.output(
-                        &ctx,
-                        &FileOpenAlert::new(ctx.pid(), binprm_inode, inode),
-                        0,
-                    );
-                    return Ok(-1);
-                }
-
-                for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                    if paths.paths[i] == inode {
-                        ALERT_FILE_OPEN.output(
-                            &ctx,
-                            &FileOpenAlert::new(ctx.pid(), binprm_inode, inode),
-                            0,
-                        );
-                        return Ok(-1);
-                    }
-                }
-
-                let mut previous_inode = inode;
-                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
-                for _ in 0..MAX_DIR_DEPTH {
-                    if parent_dentry.is_null() {
-                        break;
-                    }
-                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
-                    if inode == previous_inode {
-                        break;
-                    }
-                    for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                        if paths.paths[i] == inode {
-                            ALERT_FILE_OPEN.output(
-                                &ctx,
-                                &FileOpenAlert::new(ctx.pid(), binprm_inode, inode),
-                                0,
-                            );
-                            return Ok(-1);
-                        }
-                    }
-                    previous_inode = inode;
-                    parent_dentry = unsafe { (*parent_dentry).d_parent };
-                }
-            }
-        }
-    }
-
-    if let Some(paths) = unsafe { DENIED_FILE_OPEN.get(&INODE_WILDCARD) } {
-        if paths.all {
-            if let Some(paths) = unsafe { ALLOWED_FILE_OPEN.get(&INODE_WILDCARD) } {
-                if paths.all {
-                    return Ok(0);
-                }
-
-                for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                    if paths.paths[i] == inode {
-                        return Ok(0);
-                    }
-                }
-
-                let mut previous_inode = inode;
-                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
-                for _ in 0..MAX_DIR_DEPTH {
-                    if parent_dentry.is_null() {
-                        break;
-                    }
-                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
-                    if inode == previous_inode {
-                        break;
-                    }
-                    for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                        if paths.paths[i] == inode {
-                            return Ok(0);
-                        }
-                    }
-                    previous_inode = inode;
-                    parent_dentry = unsafe { (*parent_dentry).d_parent };
-                }
-            }
-
-            if let Some(paths) = unsafe { ALLOWED_FILE_OPEN.get(&binprm_inode) } {
-                if paths.all {
-                    return Ok(0);
-                }
-
-                for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                    if paths.paths[i] == inode {
-                        return Ok(0);
-                    }
-                }
-
-                let mut previous_inode = inode;
-                let mut parent_dentry = unsafe { (*(*file).f_path.dentry).d_parent };
-                for _ in 0..MAX_DIR_DEPTH {
-                    if parent_dentry.is_null() {
-                        break;
-                    }
-                    let inode = unsafe { (*(*parent_dentry).d_inode).i_ino };
-                    if inode == previous_inode {
-                        break;
-                    }
-                    for i in 0..cmp::min(paths.len, MAX_PATHS) {
-                        if paths.paths[i] == inode {
-                            return Ok(0);
-                        }
-                    }
-                    previous_inode = inode;
-                    parent_dentry = unsafe { (*parent_dentry).d_parent };
-                }
-            }
-            ALERT_FILE_OPEN.output(&ctx, &FileOpenAlert::new(ctx.pid(), binprm_inode, inode), 0);
-            return Ok(-1);
-        }
-    }
-
-    Ok(0)
 }
 
 #[lsm(name = "task_fix_setuid")]
-pub fn task_fix_setuid(ctx: LsmContext) -> i32 {
-    match try_task_fix_setuid(ctx) {
+pub fn prog_task_fix_setuid(ctx: LsmContext) -> i32 {
+    match task_fix_setuid(ctx) {
         Ok(ret) => ret,
         Err(_) => 0,
     }
 }
 
-fn try_task_fix_setuid(ctx: LsmContext) -> Result<i32, c_long> {
-    let new: *const cred = unsafe { ctx.arg(0) };
-    let old: *const cred = unsafe { ctx.arg(1) };
-
-    let old_uid = unsafe { (*old).uid.val };
-    let old_gid = unsafe { (*old).gid.val };
-    let new_uid = unsafe { (*new).uid.val };
-    let new_gid = unsafe { (*new).gid.val };
-
-    let binprm_inode = current_binprm_inode();
-
-    if unsafe { ALLOWED_SETUID.get(&INODE_WILDCARD) }.is_some() {
-        if unsafe { DENIED_SETUID.get(&binprm_inode).is_some() } {
-            ALERT_SETUID.output(
-                &ctx,
-                &SetuidAlert::new(ctx.pid(), binprm_inode, old_uid, old_gid, new_uid, new_gid),
-                0,
-            );
-            return Ok(-1);
-        }
-        return Ok(0);
-    }
-
-    if unsafe { DENIED_SETUID.get(&INODE_WILDCARD) }.is_some() {
-        if unsafe { ALLOWED_SETUID.get(&binprm_inode).is_some() } {
-            return Ok(0);
-        }
-        ALERT_SETUID.output(
-            &ctx,
-            &SetuidAlert::new(ctx.pid(), binprm_inode, old_uid, old_gid, new_uid, new_gid),
-            0,
-        );
-        return Ok(-1);
-    }
-
-    Ok(0)
-}
-
 #[lsm(name = "socket_bind")]
-pub fn socket_bind(ctx: LsmContext) -> i32 {
-    match try_socket_bind(ctx) {
+pub fn prog_socket_bind(ctx: LsmContext) -> i32 {
+    match socket_bind(ctx) {
         Ok(ret) => ret,
         Err(_) => 0,
     }
 }
 
 #[lsm(name = "socket_connect")]
-pub fn socket_connect(ctx: LsmContext) -> i32 {
-    match try_socket_connect(ctx) {
+pub fn prog_socket_connect(ctx: LsmContext) -> i32 {
+    match socket_connect(ctx) {
         Ok(ret) => ret,
         Err(_) => 0,
     }

--- a/guardity-ebpf/src/maps.rs
+++ b/guardity-ebpf/src/maps.rs
@@ -3,39 +3,73 @@ use aya_bpf::{
     maps::{HashMap, PerfEventArray},
 };
 use guardity_common::{
-    AlertSocketConnectV4, AlertSocketConnectV6, Ipv4Addrs, Ipv6Addrs, Ports, SocketBindAlert,
+    AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnectV4, AlertSocketConnectV6,
+    Ipv4Addrs, Ipv6Addrs, Paths, Ports,
 };
 
+/// Map of allowed file open paths for each binary.
+#[map]
+pub(crate) static ALLOWED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
+
+/// Map of denied file open paths for each binary.
+#[map]
+pub(crate) static DENIED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
+
+/// Map of alerts for `file_open` LSM hook inspection.
+#[map]
+pub(crate) static ALERT_FILE_OPEN: PerfEventArray<AlertFileOpen> = PerfEventArray::pinned(1024, 0);
+
+/// Map indicating which binaries are allowed to use `setuid`.
+#[map]
+pub(crate) static ALLOWED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
+
+/// Map indicating which binaries are denied to use `setuid`.
+#[map]
+pub(crate) static DENIED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
+
+/// Map of alerts for `setuid` LSM hook inspection.
+#[map]
+pub(crate) static ALERT_SETUID: PerfEventArray<AlertSetuid> = PerfEventArray::pinned(1024, 0);
+
+/// Map of allowed socket bind ports for each binary.
 #[map]
 pub(crate) static ALLOWED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
 
+/// Map of denied socket bind ports for each binary.
 #[map]
 pub(crate) static DENIED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
 
+/// Map of alerts for `socket_bind` LSM hook inspection.
 #[map]
-pub(crate) static ALERT_SOCKET_BIND: PerfEventArray<SocketBindAlert> =
+pub(crate) static ALERT_SOCKET_BIND: PerfEventArray<AlertSocketBind> =
     PerfEventArray::with_max_entries(1024, 0);
 
+/// Map of allowed socket connect IPv4 addresses for each binary.
 #[map]
 pub(crate) static ALLOWED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> =
     HashMap::with_max_entries(1024, 0);
 
+/// Map of denied socket connect IPv4 addresses for each binary.
 #[map]
 pub(crate) static DENIED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> =
     HashMap::with_max_entries(1024, 0);
 
+/// Map of alerts for `socket_connect` LSM hook inspection.
 #[map]
 pub(crate) static ALERT_SOCKET_CONNECT_V4: PerfEventArray<AlertSocketConnectV4> =
     PerfEventArray::with_max_entries(1024, 0);
 
+/// Map of allowed socket connect IPv6 addresses for each binary.
 #[map]
 pub(crate) static ALLOWED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> =
     HashMap::with_max_entries(1024, 0);
 
+/// Map of denied socket connect IPv6 addresses for each binary.
 #[map]
 pub(crate) static DENIED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> =
     HashMap::with_max_entries(1024, 0);
 
+/// Map of alerts for `socket_connect` LSM hook inspection.
 #[map]
 pub(crate) static ALERT_SOCKET_CONNECT_V6: PerfEventArray<AlertSocketConnectV6> =
     PerfEventArray::with_max_entries(1024, 0);

--- a/guardity-ebpf/src/setuid.rs
+++ b/guardity-ebpf/src/setuid.rs
@@ -1,0 +1,66 @@
+use aya_bpf::{cty::c_long, programs::LsmContext, BpfContext};
+use guardity_common::AlertSetuid;
+
+use crate::{
+    binprm::current_binprm_inode,
+    consts::INODE_WILDCARD,
+    maps::{ALERT_SETUID, ALLOWED_SETUID, DENIED_SETUID},
+    vmlinux::cred,
+};
+
+/// Inspects the context of `task_fix_setuid` LSM hook and decides whether to
+/// allow or deny the operation based on the state of the `ALLOWED_SETUID`
+/// and `DENIED_SETUID` maps.
+///
+/// If denied, the operation is logged to the `ALERT_SETUID` map.
+///
+/// # Example
+///
+/// ```rust
+/// use aya_bpf::{macros::lsm, programs::LsmContext};
+/// use guardity_ebpf::setuid;
+///
+/// #[lsm(name = "my_program")]
+/// pub fn my_program(ctx: LsmContext) -> i32 {
+///    match setuid::setuid(ctx) {
+///       Ok(ret) => ret,
+///       Err(_) => 0,
+/// }
+/// ```
+pub fn task_fix_setuid(ctx: LsmContext) -> Result<i32, c_long> {
+    let new: *const cred = unsafe { ctx.arg(0) };
+    let old: *const cred = unsafe { ctx.arg(1) };
+
+    let old_uid = unsafe { (*old).uid.val };
+    let old_gid = unsafe { (*old).gid.val };
+    let new_uid = unsafe { (*new).uid.val };
+    let new_gid = unsafe { (*new).gid.val };
+
+    let binprm_inode = current_binprm_inode();
+
+    if unsafe { ALLOWED_SETUID.get(&INODE_WILDCARD) }.is_some() {
+        if unsafe { DENIED_SETUID.get(&binprm_inode).is_some() } {
+            ALERT_SETUID.output(
+                &ctx,
+                &AlertSetuid::new(ctx.pid(), binprm_inode, old_uid, old_gid, new_uid, new_gid),
+                0,
+            );
+            return Ok(-1);
+        }
+        return Ok(0);
+    }
+
+    if unsafe { DENIED_SETUID.get(&INODE_WILDCARD) }.is_some() {
+        if unsafe { ALLOWED_SETUID.get(&binprm_inode).is_some() } {
+            return Ok(0);
+        }
+        ALERT_SETUID.output(
+            &ctx,
+            &AlertSetuid::new(ctx.pid(), binprm_inode, old_uid, old_gid, new_uid, new_gid),
+            0,
+        );
+        return Ok(-1);
+    }
+
+    Ok(0)
+}

--- a/guardity-ebpf/src/socket_bind.rs
+++ b/guardity-ebpf/src/socket_bind.rs
@@ -1,0 +1,137 @@
+use core::cmp;
+
+use aya_bpf::{cty::c_long, programs::LsmContext, BpfContext};
+use guardity_common::{AlertSocketBind, MAX_PORTS};
+
+use crate::{
+    binprm::current_binprm_inode,
+    consts::{AF_INET, INODE_WILDCARD},
+    maps::{ALERT_SOCKET_BIND, ALLOWED_SOCKET_BIND, DENIED_SOCKET_BIND},
+    vmlinux::{sockaddr, sockaddr_in},
+};
+
+/// Inspects the context of `socket_bind` LSM hook and decides whether to allow
+/// or deny the bind operation based on the state of the `ALLOWED_SOCKET_BIND`
+/// and `DENIED_SOCKET_BIND` maps.
+///
+/// If denied, the operation is logged to the `ALERT_SOCKET_BIND` map.
+///
+/// # Example
+///
+/// ```rust
+/// use aya_bpf::{macros::lsm, programs::LsmContext};
+/// use guardity_ebpf::socket_bind;
+///
+/// #[lsm(name = "my_program")]
+/// pub fn my_program(ctx: LsmContext) -> i32 {
+///     match socket_bind::socket_bind(ctx) {
+///         Ok(ret) => ret,
+///         Err(_) => 0,
+///     }
+/// }
+/// ```
+#[inline(always)]
+pub fn socket_bind(ctx: LsmContext) -> Result<i32, c_long> {
+    let sockaddr: *const sockaddr = unsafe { ctx.arg(1) };
+
+    if unsafe { (*sockaddr).sa_family } != AF_INET {
+        return Ok(0);
+    }
+
+    let sockaddr_in: *const sockaddr_in = sockaddr as *const sockaddr_in;
+    let port = u16::from_be(unsafe { (*sockaddr_in).sin_port });
+
+    let binprm_inode = current_binprm_inode();
+
+    if let Some(ports) = unsafe { ALLOWED_SOCKET_BIND.get(&INODE_WILDCARD) } {
+        if ports.all {
+            if let Some(ports) = unsafe { DENIED_SOCKET_BIND.get(&INODE_WILDCARD) } {
+                if ports.all {
+                    ALERT_SOCKET_BIND.output(
+                        &ctx,
+                        &AlertSocketBind::new(ctx.pid(), binprm_inode, port),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+                let len = cmp::min(ports.len, MAX_PORTS);
+                if ports.ports[..len].contains(&port) {
+                    ALERT_SOCKET_BIND.output(
+                        &ctx,
+                        &AlertSocketBind::new(ctx.pid(), binprm_inode, port),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+            }
+
+            if let Some(ports) = unsafe { DENIED_SOCKET_BIND.get(&binprm_inode) } {
+                if ports.all {
+                    ALERT_SOCKET_BIND.output(
+                        &ctx,
+                        &AlertSocketBind::new(ctx.pid(), binprm_inode, port),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+                let len = cmp::min(ports.len, MAX_PORTS);
+                if ports.ports[..len].contains(&port) {
+                    ALERT_SOCKET_BIND.output(
+                        &ctx,
+                        &AlertSocketBind::new(ctx.pid(), binprm_inode, port),
+                        0,
+                    );
+                    return Ok(-1);
+                }
+            }
+        } else {
+            let len = cmp::min(ports.len, MAX_PORTS);
+            if ports.ports[..len].contains(&port) {
+                return Ok(0);
+            }
+        }
+    }
+
+    if let Some(ports) = unsafe { DENIED_SOCKET_BIND.get(&INODE_WILDCARD) } {
+        if ports.all {
+            if let Some(ports) = unsafe { ALLOWED_SOCKET_BIND.get(&INODE_WILDCARD) } {
+                if ports.all {
+                    return Ok(0);
+                }
+                let len = cmp::min(ports.len, MAX_PORTS);
+                if ports.ports[..len].contains(&port) {
+                    return Ok(0);
+                }
+            }
+
+            if let Some(ports) = unsafe { ALLOWED_SOCKET_BIND.get(&binprm_inode) } {
+                if ports.all {
+                    return Ok(0);
+                }
+                let len = cmp::min(ports.len, MAX_PORTS);
+                if ports.ports[..len].contains(&port) {
+                    return Ok(0);
+                }
+            }
+
+            ALERT_SOCKET_BIND.output(
+                &ctx,
+                &AlertSocketBind::new(ctx.pid(), binprm_inode, port),
+                0,
+            );
+            return Ok(-1);
+        } else {
+            let len = cmp::min(ports.len, MAX_PORTS);
+            if ports.ports[..len].contains(&port) {
+                ALERT_SOCKET_BIND.output(
+                    &ctx,
+                    &AlertSocketBind::new(ctx.pid(), binprm_inode, port),
+                    0,
+                );
+                return Ok(-1);
+            }
+        }
+    }
+
+    Ok(0)
+}

--- a/guardity/src/main.rs
+++ b/guardity/src/main.rs
@@ -9,7 +9,7 @@ use aya_log::BpfLogger;
 use bytes::BytesMut;
 use clap::Parser;
 use guardity_common::{
-    AlertSocketConnectV4, AlertSocketConnectV6, FileOpenAlert, SetuidAlert, SocketBindAlert,
+    AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnectV4, AlertSocketConnectV6,
 };
 use log::{info, warn};
 use serde::Serialize;
@@ -100,9 +100,9 @@ async fn main() -> Result<(), anyhow::Error> {
         }
     }
 
-    read_alerts::<FileOpenAlert>(bpf.take_map("ALERT_FILE_OPEN").unwrap().try_into()?).await;
-    read_alerts::<SetuidAlert>(bpf.take_map("ALERT_SETUID").unwrap().try_into()?).await;
-    read_alerts::<SocketBindAlert>(bpf.take_map("ALERT_SOCKET_BIND").unwrap().try_into()?).await;
+    read_alerts::<AlertFileOpen>(bpf.take_map("ALERT_FILE_OPEN").unwrap().try_into()?).await;
+    read_alerts::<AlertSetuid>(bpf.take_map("ALERT_SETUID").unwrap().try_into()?).await;
+    read_alerts::<AlertSocketBind>(bpf.take_map("ALERT_SOCKET_BIND").unwrap().try_into()?).await;
     read_alerts::<AlertSocketConnectV4>(
         bpf.take_map("ALERT_SOCKET_CONNECT_V4")
             .unwrap()


### PR DESCRIPTION
Split the eBPF crate into library with separate modules and binary (which only defines the program entrypoints and calls the library functions to perform the actual inspection).