### PR TITLE
Fix `socket_connect` policy

### DIFF
--- a/guardity-common/src/lib.rs
+++ b/guardity-common/src/lib.rs
@@ -1,4 +1,10 @@
-#![no_std]
+#![cfg_attr(not(feature = "user"), no_std)]
+
+#[cfg(feature = "user")]
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[cfg(feature = "user")]
+use serde::Serialize;
 
 pub const MAX_PATHS: usize = 1;
 pub const MAX_PORTS: usize = 1;
@@ -10,6 +16,7 @@ pub const MAX_IPV6ADDRS: usize = 1;
 #[derive(Copy, Clone)]
 pub struct AlertFileOpen {
     pub pid: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding: u32,
     pub binprm_inode: u64,
     pub inode: u64,
@@ -31,6 +38,7 @@ impl AlertFileOpen {
 #[derive(Copy, Clone)]
 pub struct AlertSetuid {
     pub pid: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding: u32,
     pub binprm_inode: u64,
     pub old_uid: u32,
@@ -65,9 +73,11 @@ impl AlertSetuid {
 #[derive(Copy, Clone)]
 pub struct AlertSocketBind {
     pub pid: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding1: u32,
     pub binprm_inode: u64,
     pub port: u16,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding2: [u16; 3],
 }
 
@@ -83,14 +93,25 @@ impl AlertSocketBind {
     }
 }
 
+#[cfg(feature = "user")]
+fn serialize_ipv4<S>(addr: &u32, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    Ipv4Addr::from(*addr).serialize(s)
+}
+
 #[repr(C)]
 #[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
 pub struct AlertSocketConnectV4 {
     pub pid: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding1: u32,
     pub binprm_inode: u64,
+    #[cfg_attr(feature = "user", serde(serialize_with = "serialize_ipv4"))]
     pub addr: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding2: u32,
 }
 
@@ -106,13 +127,23 @@ impl AlertSocketConnectV4 {
     }
 }
 
+#[cfg(feature = "user")]
+fn serialize_ipv6<S>(addr: &[u8; 16], s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    Ipv6Addr::from(addr.to_owned()).serialize(s)
+}
+
 #[repr(C)]
 #[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
 pub struct AlertSocketConnectV6 {
     pub pid: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
     pub _padding1: u32,
     pub binprm_inode: u64,
+    #[cfg_attr(feature = "user", serde(serialize_with = "serialize_ipv6"))]
     pub addr: [u8; 16],
 }
 

--- a/guardity-ebpf/src/maps.rs
+++ b/guardity-ebpf/src/maps.rs
@@ -42,34 +42,30 @@ pub(crate) static DENIED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024
 /// Map of alerts for `socket_bind` LSM hook inspection.
 #[map]
 pub(crate) static ALERT_SOCKET_BIND: PerfEventArray<AlertSocketBind> =
-    PerfEventArray::with_max_entries(1024, 0);
+    PerfEventArray::pinned(1024, 0);
 
 /// Map of allowed socket connect IPv4 addresses for each binary.
 #[map]
-pub(crate) static ALLOWED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> =
-    HashMap::with_max_entries(1024, 0);
+pub(crate) static ALLOWED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of denied socket connect IPv4 addresses for each binary.
 #[map]
-pub(crate) static DENIED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> =
-    HashMap::with_max_entries(1024, 0);
+pub(crate) static DENIED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `socket_connect` LSM hook inspection.
 #[map]
 pub(crate) static ALERT_SOCKET_CONNECT_V4: PerfEventArray<AlertSocketConnectV4> =
-    PerfEventArray::with_max_entries(1024, 0);
+    PerfEventArray::pinned(1024, 0);
 
 /// Map of allowed socket connect IPv6 addresses for each binary.
 #[map]
-pub(crate) static ALLOWED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> =
-    HashMap::with_max_entries(1024, 0);
+pub(crate) static ALLOWED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of denied socket connect IPv6 addresses for each binary.
 #[map]
-pub(crate) static DENIED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> =
-    HashMap::with_max_entries(1024, 0);
+pub(crate) static DENIED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `socket_connect` LSM hook inspection.
 #[map]
 pub(crate) static ALERT_SOCKET_CONNECT_V6: PerfEventArray<AlertSocketConnectV6> =
-    PerfEventArray::with_max_entries(1024, 0);
+    PerfEventArray::pinned(1024, 0);

--- a/guardity-ebpf/src/socket_bind.rs
+++ b/guardity-ebpf/src/socket_bind.rs
@@ -41,6 +41,10 @@ pub fn socket_bind(ctx: LsmContext) -> Result<i32, c_long> {
     let sockaddr_in: *const sockaddr_in = sockaddr as *const sockaddr_in;
     let port = u16::from_be(unsafe { (*sockaddr_in).sin_port });
 
+    if port == 0 {
+        return Ok(0);
+    }
+
     let binprm_inode = current_binprm_inode();
 
     if let Some(ports) = unsafe { ALLOWED_SOCKET_BIND.get(&INODE_WILDCARD) } {

--- a/guardity/src/policy/mod.rs
+++ b/guardity/src/policy/mod.rs
@@ -127,14 +127,18 @@ impl Addresses {
                 let mut ebpf_addrs_v4 = [0; guardity_common::MAX_IPV4ADDRS];
                 let mut ebpf_addrs_v6_len = 0;
                 let mut ebpf_addrs_v6 = [[0u8; 16]; guardity_common::MAX_IPV6ADDRS];
-                for (i, addr) in addrs.iter().enumerate() {
+                let mut i_v4 = 0;
+                let mut i_v6 = 0;
+                for addr in addrs.iter() {
                     match addr {
                         IpAddr::V4(ipv4) => {
-                            ebpf_addrs_v4[i] = (*ipv4).into();
+                            ebpf_addrs_v4[i_v4] = (*ipv4).into();
+                            i_v4 += 1;
                             ebpf_addrs_v4_len += 1;
                         }
                         IpAddr::V6(ipv6) => {
-                            ebpf_addrs_v6[i] = ipv6.octets();
+                            ebpf_addrs_v6[i_v6] = ipv6.octets();
+                            i_v6 += 1;
                             ebpf_addrs_v6_len += 1;
                         }
                     }

--- a/policy.yaml
+++ b/policy.yaml
@@ -10,7 +10,13 @@
   deny: !paths
     - /home/vadorovsky/forbidden
 - !socket_bind
-  subject: !process /usr/bin/python
+  subject: all
   allow: !ports
     - 8080
   deny: all
+- !socket_connect
+  subject: all
+  allow: all
+  deny: !addresses
+    - 142.250.185.206
+    - 2a00:1450:4016:809::200e


### PR DESCRIPTION
* Always allow sockets with port `0` (UNIX sockets).
* Format IP addresses in alerts.
* Don't serialize padding fields in alerts.