### PR TITLE
Split into library and modules

### DIFF
--- a/guardity-ebpf/Cargo.toml
+++ b/guardity-ebpf/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 guardity-common = { path = "../guardity-common" }
 
 [lib]

--- a/guardity-ebpf/src/file_open.rs
+++ b/guardity-ebpf/src/file_open.rs
@@ -6,8 +6,8 @@ use guardity_common::{AlertFileOpen, MAX_PATHS};
 use crate::{
     binprm::current_binprm_inode,
     consts::INODE_WILDCARD,
-    maps::{ALERT_FILE_OPEN, ALLOWED_FILE_OPEN, DENIED_FILE_OPEN},
-    vmlinux::file,
+    // maps::{ALERT_FILE_OPEN, ALLOWED_FILE_OPEN, DENIED_FILE_OPEN},
+    vmlinux::file, maps::{ALLOWED_FILE_OPEN, DENIED_FILE_OPEN, ALERT_FILE_OPEN},
 };
 
 const MAX_DIR_DEPTH: usize = 16;

--- a/guardity-ebpf/src/maps.rs
+++ b/guardity-ebpf/src/maps.rs
@@ -3,69 +3,64 @@ use aya_bpf::{
     maps::{HashMap, PerfEventArray},
 };
 use guardity_common::{
-    AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnectV4, AlertSocketConnectV6,
-    Ipv4Addrs, Ipv6Addrs, Paths, Ports,
+    AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnect, Ipv4Addrs, Ipv6Addrs, Paths,
+    Ports,
 };
 
 /// Map of allowed file open paths for each binary.
 #[map]
-pub(crate) static ALLOWED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
+pub static ALLOWED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
 
 /// Map of denied file open paths for each binary.
 #[map]
-pub(crate) static DENIED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
+pub static DENIED_FILE_OPEN: HashMap<u64, Paths> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `file_open` LSM hook inspection.
 #[map]
-pub(crate) static ALERT_FILE_OPEN: PerfEventArray<AlertFileOpen> = PerfEventArray::pinned(1024, 0);
+pub static ALERT_FILE_OPEN: PerfEventArray<AlertFileOpen> = PerfEventArray::pinned(1024, 0);
 
 /// Map indicating which binaries are allowed to use `setuid`.
 #[map]
-pub(crate) static ALLOWED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
+pub static ALLOWED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
 
 /// Map indicating which binaries are denied to use `setuid`.
 #[map]
-pub(crate) static DENIED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
+pub static DENIED_SETUID: HashMap<u64, u8> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `setuid` LSM hook inspection.
 #[map]
-pub(crate) static ALERT_SETUID: PerfEventArray<AlertSetuid> = PerfEventArray::pinned(1024, 0);
+pub static ALERT_SETUID: PerfEventArray<AlertSetuid> = PerfEventArray::pinned(1024, 0);
 
 /// Map of allowed socket bind ports for each binary.
 #[map]
-pub(crate) static ALLOWED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
+pub static ALLOWED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
 
 /// Map of denied socket bind ports for each binary.
 #[map]
-pub(crate) static DENIED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
+pub static DENIED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `socket_bind` LSM hook inspection.
 #[map]
-pub(crate) static ALERT_SOCKET_BIND: PerfEventArray<AlertSocketBind> =
+pub static ALERT_SOCKET_BIND: PerfEventArray<AlertSocketBind> =
     PerfEventArray::pinned(1024, 0);
 
 /// Map of allowed socket connect IPv4 addresses for each binary.
 #[map]
-pub(crate) static ALLOWED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> = HashMap::pinned(1024, 0);
+pub static ALLOWED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of denied socket connect IPv4 addresses for each binary.
 #[map]
-pub(crate) static DENIED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> = HashMap::pinned(1024, 0);
-
-/// Map of alerts for `socket_connect` LSM hook inspection.
-#[map]
-pub(crate) static ALERT_SOCKET_CONNECT_V4: PerfEventArray<AlertSocketConnectV4> =
-    PerfEventArray::pinned(1024, 0);
+pub static DENIED_SOCKET_CONNECT_V4: HashMap<u64, Ipv4Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of allowed socket connect IPv6 addresses for each binary.
 #[map]
-pub(crate) static ALLOWED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> = HashMap::pinned(1024, 0);
+pub static ALLOWED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of denied socket connect IPv6 addresses for each binary.
 #[map]
-pub(crate) static DENIED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> = HashMap::pinned(1024, 0);
+pub static DENIED_SOCKET_CONNECT_V6: HashMap<u64, Ipv6Addrs> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `socket_connect` LSM hook inspection.
 #[map]
-pub(crate) static ALERT_SOCKET_CONNECT_V6: PerfEventArray<AlertSocketConnectV6> =
+pub static ALERT_SOCKET_CONNECT: PerfEventArray<AlertSocketConnect> =
     PerfEventArray::pinned(1024, 0);

--- a/guardity-ebpf/src/setuid.rs
+++ b/guardity-ebpf/src/setuid.rs
@@ -4,8 +4,7 @@ use guardity_common::AlertSetuid;
 use crate::{
     binprm::current_binprm_inode,
     consts::INODE_WILDCARD,
-    maps::{ALERT_SETUID, ALLOWED_SETUID, DENIED_SETUID},
-    vmlinux::cred,
+    vmlinux::cred, maps::{ALLOWED_SETUID, DENIED_SETUID, ALERT_SETUID},
 };
 
 /// Inspects the context of `task_fix_setuid` LSM hook and decides whether to

--- a/guardity-ebpf/src/socket_connect.rs
+++ b/guardity-ebpf/src/socket_connect.rs
@@ -1,14 +1,14 @@
 use core::cmp;
 
 use aya_bpf::{cty::c_long, helpers::bpf_probe_read_kernel, programs::LsmContext, BpfContext};
-use guardity_common::{AlertSocketConnectV4, AlertSocketConnectV6, MAX_IPV4ADDRS, MAX_IPV6ADDRS};
+use guardity_common::{AlertSocketConnect, MAX_IPV4ADDRS, MAX_IPV6ADDRS};
 
 use crate::{
     binprm::current_binprm_inode,
     consts::{AF_INET, AF_INET6, INODE_WILDCARD},
     maps::{
-        ALERT_SOCKET_CONNECT_V4, ALERT_SOCKET_CONNECT_V6, ALLOWED_SOCKET_CONNECT_V4,
-        ALLOWED_SOCKET_CONNECT_V6, DENIED_SOCKET_CONNECT_V4, DENIED_SOCKET_CONNECT_V6,
+        ALERT_SOCKET_CONNECT, ALLOWED_SOCKET_CONNECT_V4, ALLOWED_SOCKET_CONNECT_V6,
+        DENIED_SOCKET_CONNECT_V4, DENIED_SOCKET_CONNECT_V6,
     },
     vmlinux::{sockaddr, sockaddr_in, sockaddr_in6},
 };
@@ -24,18 +24,18 @@ fn socket_connect_v4(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<i32, 
         if addrs.all {
             if let Some(addrs) = unsafe { DENIED_SOCKET_CONNECT_V4.get(&INODE_WILDCARD) } {
                 if addrs.all {
-                    ALERT_SOCKET_CONNECT_V4.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV4::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv4(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
                 }
                 let len = cmp::min(addrs.len, MAX_IPV4ADDRS);
                 if addrs.addrs[..len].contains(&addr) {
-                    ALERT_SOCKET_CONNECT_V4.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV4::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv4(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
@@ -44,18 +44,18 @@ fn socket_connect_v4(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<i32, 
 
             if let Some(addrs) = unsafe { DENIED_SOCKET_CONNECT_V4.get(&binprm_inode) } {
                 if addrs.all {
-                    ALERT_SOCKET_CONNECT_V4.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV4::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv4(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
                 }
                 let len = cmp::min(addrs.len, MAX_IPV4ADDRS);
                 if addrs.addrs[..len].contains(&addr) {
-                    ALERT_SOCKET_CONNECT_V4.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV4::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv4(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
@@ -91,18 +91,18 @@ fn socket_connect_v4(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<i32, 
                 }
             }
 
-            ALERT_SOCKET_CONNECT_V4.output(
+            ALERT_SOCKET_CONNECT.output(
                 &ctx,
-                &AlertSocketConnectV4::new(ctx.pid(), binprm_inode, addr),
+                &AlertSocketConnect::new_ipv4(ctx.pid(), binprm_inode, addr),
                 0,
             );
             return Ok(-1);
         } else {
             let len = cmp::min(addrs.len, MAX_IPV4ADDRS);
             if addrs.addrs[..len].contains(&addr) {
-                ALERT_SOCKET_CONNECT_V4.output(
+                ALERT_SOCKET_CONNECT.output(
                     &ctx,
-                    &AlertSocketConnectV4::new(ctx.pid(), binprm_inode, addr),
+                    &AlertSocketConnect::new_ipv4(ctx.pid(), binprm_inode, addr),
                     0,
                 );
                 return Ok(-1);
@@ -126,18 +126,18 @@ fn socket_connect_v6(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<i32, 
         if addrs.all {
             if let Some(addrs) = unsafe { DENIED_SOCKET_CONNECT_V6.get(&INODE_WILDCARD) } {
                 if addrs.all {
-                    ALERT_SOCKET_CONNECT_V6.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV6::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv6(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
                 }
                 let len = cmp::min(addrs.len, MAX_IPV6ADDRS);
                 if addrs.addrs[..len].contains(&addr) {
-                    ALERT_SOCKET_CONNECT_V6.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV6::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv6(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
@@ -146,18 +146,18 @@ fn socket_connect_v6(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<i32, 
 
             if let Some(addrs) = unsafe { DENIED_SOCKET_CONNECT_V6.get(&binprm_inode) } {
                 if addrs.all {
-                    ALERT_SOCKET_CONNECT_V6.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV6::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv6(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
                 }
                 let len = cmp::min(addrs.len, MAX_IPV6ADDRS);
                 if addrs.addrs[..len].contains(&addr) {
-                    ALERT_SOCKET_CONNECT_V6.output(
+                    ALERT_SOCKET_CONNECT.output(
                         &ctx,
-                        &AlertSocketConnectV6::new(ctx.pid(), binprm_inode, addr),
+                        &AlertSocketConnect::new_ipv6(ctx.pid(), binprm_inode, addr),
                         0,
                     );
                     return Ok(-1);
@@ -193,18 +193,18 @@ fn socket_connect_v6(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<i32, 
                 }
             }
 
-            ALERT_SOCKET_CONNECT_V6.output(
+            ALERT_SOCKET_CONNECT.output(
                 &ctx,
-                &AlertSocketConnectV6::new(ctx.pid(), binprm_inode, addr),
+                &AlertSocketConnect::new_ipv6(ctx.pid(), binprm_inode, addr),
                 0,
             );
             return Ok(-1);
         } else {
             let len = cmp::min(addrs.len, MAX_IPV6ADDRS);
             if addrs.addrs[..len].contains(&addr) {
-                ALERT_SOCKET_CONNECT_V6.output(
+                ALERT_SOCKET_CONNECT.output(
                     &ctx,
-                    &AlertSocketConnectV6::new(ctx.pid(), binprm_inode, addr),
+                    &AlertSocketConnect::new_ipv6(ctx.pid(), binprm_inode, addr),
                     0,
                 );
                 return Ok(-1);

--- a/guardity/Cargo.toml
+++ b/guardity/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 aya = { git = "https://github.com/aya-rs/aya", branch = "main", features=["async_tokio"] }
-aya-log = { git = "https://github.com/aya-rs/aya", branch = "main" }
 bytes = "1.4"
 clap = { version = "4.2", features = ["derive"] }
 guardity-common = { path = "../guardity-common", features = ["user"] }
@@ -17,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+thiserror = "1.0"
 
 [[bin]]
 name = "guardity"

--- a/guardity/src/lib.rs
+++ b/guardity/src/lib.rs
@@ -1,2 +1,126 @@
+use std::path::Path;
+
+use aya::{
+    include_bytes_aligned,
+    programs::{lsm::LsmLink, Lsm},
+    Bpf, BpfLoader, Btf,
+};
+
 pub mod fs;
 pub mod policy;
+
+pub struct PolicyManager {
+    pub bpf: Bpf,
+    pub file_open: Option<Hook>,
+    pub setuid: Option<Hook>,
+    pub socket_bind: Option<Hook>,
+    pub socket_connect: Option<Hook>,
+}
+
+pub type Foo = Option<u32>;
+
+impl PolicyManager {
+    pub fn new<P: AsRef<Path>>(bpf_path: P) -> anyhow::Result<Self> {
+        #[cfg(debug_assertions)]
+        let bpf = BpfLoader::new()
+            .map_pin_path(&bpf_path)
+            .load(include_bytes_aligned!(
+                "../../target/bpfel-unknown-none/debug/guardity"
+            ))?;
+        #[cfg(not(debug_assertions))]
+        let bpf = BpfLoader::new()
+            .map_pin_path(&bpf_path)
+            .load(include_bytes_aligned!(
+                "../../target/bpfel-unknown-none/release/guardity"
+            ))?;
+
+        Ok(Self {
+            bpf,
+            file_open: None,
+            setuid: None,
+            socket_bind: None,
+            socket_connect: None,
+        })
+    }
+
+    pub fn attach_file_open(&mut self) -> anyhow::Result<()> {
+        let link = attach_program(&mut self.bpf, "file_open")?;
+        let file_open = Hook::new(link)?;
+        self.file_open = Some(file_open);
+
+        Ok(())
+    }
+
+    pub fn file_open(&mut self) -> anyhow::Result<&mut Hook> {
+        match self.file_open {
+            Some(ref mut file_open) => Ok(file_open),
+            None => Err(anyhow::anyhow!("file_open is not attached")),
+        }
+    }
+
+    pub fn attach_task_fix_setuid(&mut self) -> anyhow::Result<()> {
+        let link = attach_program(&mut self.bpf, "task_fix_setuid")?;
+        let setuid = Hook::new(link)?;
+        self.setuid = Some(setuid);
+
+        Ok(())
+    }
+
+    pub fn setuid(&mut self) -> anyhow::Result<&mut Hook> {
+        match self.setuid {
+            Some(ref mut setuid) => Ok(setuid),
+            None => Err(anyhow::anyhow!("setuid is not attached")),
+        }
+    }
+
+    pub fn attach_socket_bind(&mut self) -> anyhow::Result<()> {
+        let link = attach_program(&mut self.bpf, "socket_bind")?;
+        let socket_bind = Hook::new(link)?;
+        self.socket_bind = Some(socket_bind);
+
+        Ok(())
+    }
+
+    pub fn socket_bind(&mut self) -> anyhow::Result<&mut Hook> {
+        match self.socket_bind {
+            Some(ref mut socket_bind) => Ok(socket_bind),
+            None => Err(anyhow::anyhow!("socket_bind is not attached")),
+        }
+    }
+
+    pub fn attach_socket_connect(&mut self) -> anyhow::Result<()> {
+        let link = attach_program(&mut self.bpf, "socket_connect")?;
+        let socket_connect = Hook::new(link)?;
+        self.socket_connect = Some(socket_connect);
+
+        Ok(())
+    }
+
+    pub fn socket_connect(&mut self) -> anyhow::Result<&mut Hook> {
+        match self.socket_connect {
+            Some(ref mut socket_connect) => Ok(socket_connect),
+            None => Err(anyhow::anyhow!("socket_connect is not attached")),
+        }
+    }
+}
+
+fn attach_program(bpf: &mut Bpf, name: &str) -> anyhow::Result<LsmLink> {
+    let btf = Btf::from_sys_fs()?;
+    let program: &mut Lsm = bpf.program_mut(name).unwrap().try_into()?;
+    program.load(name, &btf)?;
+    let link_id = program.attach()?;
+    let link = program.take_link(link_id)?;
+
+    Ok(link)
+}
+
+pub struct Hook {
+    #[allow(dead_code)]
+    program_link: LsmLink,
+}
+
+impl Hook {
+    pub fn new(program_link: LsmLink) -> anyhow::Result<Self> {
+        Ok(Self { program_link })
+    }
+}


### PR DESCRIPTION
Split the user space crate into library and binary, where library provides functions to provide LSM policies as a code.