### PR TITLE
Add `bprm_check_security` hook

### DIFF
--- a/guardity-ebpf/src/bprm_check_security.rs
+++ b/guardity-ebpf/src/bprm_check_security.rs
@@ -1,0 +1,14 @@
+use aya_bpf::{cty::c_long, programs::LsmContext};
+
+use crate::vmlinux::linux_binprm;
+
+pub fn bprm_check_security(ctx: LsmContext) -> Result<i32, c_long> {
+    let binprm: *const linux_binprm = unsafe { ctx.arg(0) };
+    let argc = unsafe { (*binprm).argc };
+
+    if argc < 1 {
+        return Ok(-1);
+    }
+
+    Ok(0)
+}

--- a/guardity-ebpf/src/lib.rs
+++ b/guardity-ebpf/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod binprm;
+pub mod bprm_check_security;
 pub mod consts;
 pub mod file_open;
 pub mod maps;

--- a/guardity-ebpf/src/main.rs
+++ b/guardity-ebpf/src/main.rs
@@ -4,9 +4,17 @@
 use aya_bpf::{macros::lsm, programs::LsmContext};
 
 use guardity_ebpf::{
-    file_open::file_open, setuid::task_fix_setuid, socket_bind::socket_bind,
-    socket_connect::socket_connect,
+    bprm_check_security::bprm_check_security, file_open::file_open, setuid::task_fix_setuid,
+    socket_bind::socket_bind, socket_connect::socket_connect,
 };
+
+#[lsm(name = "bprm_check_security")]
+pub fn prog_bprm_check_security(ctx: LsmContext) -> i32 {
+    match bprm_check_security(ctx) {
+        Ok(ret) => ret,
+        Err(_) => 0,
+    }
+}
 
 #[lsm(name = "file_open")]
 pub fn prog_file_open(ctx: LsmContext) -> i32 {

--- a/guardity/src/lib.rs
+++ b/guardity/src/lib.rs
@@ -11,6 +11,7 @@ pub mod policy;
 
 pub struct PolicyManager {
     pub bpf: Bpf,
+    pub bprm_check_security: Option<Hook>,
     pub file_open: Option<Hook>,
     pub setuid: Option<Hook>,
     pub socket_bind: Option<Hook>,
@@ -36,11 +37,20 @@ impl PolicyManager {
 
         Ok(Self {
             bpf,
+            bprm_check_security: None,
             file_open: None,
             setuid: None,
             socket_bind: None,
             socket_connect: None,
         })
+    }
+
+    pub fn attach_bprm_check_security(&mut self) -> anyhow::Result<()> {
+        let link = attach_program(&mut self.bpf, "bprm_check_security")?;
+        let bprm_check_security = Hook::new(link)?;
+        self.bprm_check_security = Some(bprm_check_security);
+
+        Ok(())
     }
 
     pub fn attach_file_open(&mut self) -> anyhow::Result<()> {

--- a/guardity/src/main.rs
+++ b/guardity/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<(), anyhow::Error> {
     create_dir_all(&bpf_path)?;
 
     let mut policy_manager = PolicyManager::new(bpf_path)?;
+    policy_manager.attach_bprm_check_security()?;
     policy_manager.attach_file_open()?;
     policy_manager.attach_task_fix_setuid()?;
     policy_manager.attach_socket_bind()?;


### PR DESCRIPTION
Use it to deny all new processes which have `argc` < 1, to prevent vulnerabilities which take an advantage of programs which don't check `argc` and therefore executing them with empty `argv` might result in treating `envp` as `argv` (like CVE-2021-4034 in polkit).