### PR TITLE
common: Store just an array in `Ipv*Addrs` structs

### DIFF
--- a/guardctl/src/policy/socket_connect.rs
+++ b/guardctl/src/policy/socket_connect.rs
@@ -45,7 +45,7 @@ pub(crate) fn list_socket_connect(bpf: &mut Bpf) -> anyhow::Result<TableStruct> 
     for subject in subjects {
         let mut allowed = match allowed_socket_connect_v4.get(&subject, 0) {
             Ok(allowed) => {
-                if allowed.all {
+                if allowed.all() {
                     Addresses::All
                 } else {
                     Addresses::Addresses(
@@ -63,7 +63,7 @@ pub(crate) fn list_socket_connect(bpf: &mut Bpf) -> anyhow::Result<TableStruct> 
         if let Addresses::Addresses(addrs) = &mut allowed {
             match allowed_socket_connect_v6.get(&subject, 0) {
                 Ok(allowed) => {
-                    if allowed.all {
+                    if allowed.all() {
                         anyhow::bail!("Inconsistent policies: allowed all IPv6 addresses, but specified IPv4 addresses")
                     } else {
                         addrs.extend(allowed.addrs.iter().map(|a| IpAddr::V6(Ipv6Addr::from(*a))));
@@ -76,7 +76,7 @@ pub(crate) fn list_socket_connect(bpf: &mut Bpf) -> anyhow::Result<TableStruct> 
 
         let mut denied = match denied_socket_connect_v4.get(&subject, 0) {
             Ok(denied) => {
-                if denied.all {
+                if denied.all() {
                     Addresses::All
                 } else {
                     Addresses::Addresses(
@@ -94,7 +94,7 @@ pub(crate) fn list_socket_connect(bpf: &mut Bpf) -> anyhow::Result<TableStruct> 
         if let Addresses::Addresses(addrs) = &mut denied {
             match denied_socket_connect_v6.get(&subject, 0) {
                 Ok(denied) => {
-                    if denied.all {
+                    if denied.all() {
                         anyhow::bail!("Inconsistent policies: denied all IPv6 addresses, but specified IPv4 addresses")
                     } else {
                         addrs.extend(denied.addrs.iter().map(|a| IpAddr::V6(Ipv6Addr::from(*a))));

--- a/guardity-common/src/lib.rs
+++ b/guardity-common/src/lib.rs
@@ -194,61 +194,46 @@ impl Ports {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Ipv4Addrs {
-    pub all: bool,
-    pub _padding1: [u8; 7],
-    pub len: usize,
     pub addrs: [u32; MAX_IPV4ADDRS],
-    pub _padding2: [u32; MAX_IPV4ADDRS],
 }
 
 impl Ipv4Addrs {
-    pub fn new(len: usize, addrs: [u32; MAX_IPV4ADDRS]) -> Self {
-        Self {
-            all: false,
-            _padding1: [0; 7],
-            len,
-            addrs,
-            _padding2: [0; MAX_IPV4ADDRS],
-        }
+    pub fn new(addrs: [u32; MAX_IPV4ADDRS]) -> Self {
+        Self { addrs }
     }
 
     pub fn new_all() -> Self {
         Self {
-            all: true,
-            _padding1: [0; 7],
-            len: 0,
             addrs: [0; MAX_IPV4ADDRS],
-            _padding2: [0; MAX_IPV4ADDRS],
         }
+    }
+
+    #[inline(always)]
+    pub fn all(&self) -> bool {
+        self.addrs[0] == 0
     }
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Ipv6Addrs {
-    pub all: bool,
-    pub _padding1: [u8; 7],
-    pub len: usize,
     pub addrs: [[u8; 16]; MAX_IPV4ADDRS],
 }
 
 impl Ipv6Addrs {
-    pub fn new(len: usize, addrs: [[u8; 16]; MAX_IPV4ADDRS]) -> Self {
-        Self {
-            all: false,
-            _padding1: [0; 7],
-            len,
-            addrs,
-        }
+    pub fn new(addrs: [[u8; 16]; MAX_IPV4ADDRS]) -> Self {
+        Self { addrs }
     }
 
     pub fn new_all() -> Self {
         Self {
-            all: true,
-            _padding1: [0; 7],
-            len: 0,
             addrs: [[0; 16]; MAX_IPV4ADDRS],
         }
+    }
+
+    #[inline(always)]
+    pub fn all(&self) -> bool {
+        self.addrs[0] == [0; 16]
     }
 }
 

--- a/guardity/src/policy/mod.rs
+++ b/guardity/src/policy/mod.rs
@@ -125,9 +125,7 @@ impl Addresses {
                 guardity_common::Ipv6Addrs::new_all(),
             ),
             Addresses::Addresses(addrs) => {
-                let mut ebpf_addrs_v4_len = 0;
                 let mut ebpf_addrs_v4 = [0; guardity_common::MAX_IPV4ADDRS];
-                let mut ebpf_addrs_v6_len = 0;
                 let mut ebpf_addrs_v6 = [[0u8; 16]; guardity_common::MAX_IPV6ADDRS];
                 let mut i_v4 = 0;
                 let mut i_v6 = 0;
@@ -136,18 +134,16 @@ impl Addresses {
                         IpAddr::V4(ipv4) => {
                             ebpf_addrs_v4[i_v4] = (*ipv4).into();
                             i_v4 += 1;
-                            ebpf_addrs_v4_len += 1;
                         }
                         IpAddr::V6(ipv6) => {
                             ebpf_addrs_v6[i_v6] = ipv6.octets();
                             i_v6 += 1;
-                            ebpf_addrs_v6_len += 1;
                         }
                     }
                 }
                 (
-                    guardity_common::Ipv4Addrs::new(ebpf_addrs_v4_len, ebpf_addrs_v4),
-                    guardity_common::Ipv6Addrs::new(ebpf_addrs_v6_len, ebpf_addrs_v6),
+                    guardity_common::Ipv4Addrs::new(ebpf_addrs_v4),
+                    guardity_common::Ipv6Addrs::new(ebpf_addrs_v6),
                 )
             }
         }


### PR DESCRIPTION
Addresses represented by `0` or arrays with zeros are wildcard. So when the first element of the array is `0` or `[0u8; 16]`, we can just assume that we have a wildcard policy. Therefore we can get rid of the `all` field.

`len` field would be useful to reduce the number of iterations when matching, but it trips the verifier.