### PR TITLE
ebpf: Refactor `socket_connect` function

### DIFF
--- a/guardctl/src/policy/socket_connect.rs
+++ b/guardctl/src/policy/socket_connect.rs
@@ -6,6 +6,7 @@ use std::{
 use aya::{maps::HashMap, Bpf};
 use cli_table::{Cell, Style, Table, TableStruct};
 use guardity::policy::engine::INODE_WILDCARD;
+use guardity_common::IpAddrs;
 
 enum Addresses {
     All,

--- a/guardity-common/src/lib.rs
+++ b/guardity-common/src/lib.rs
@@ -191,6 +191,11 @@ impl Ports {
     }
 }
 
+pub trait IpAddrs<T, const U: usize> {
+    fn all(&self) -> bool;
+    fn addrs(&self) -> [T; U];
+}
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Ipv4Addrs {
@@ -207,10 +212,17 @@ impl Ipv4Addrs {
             addrs: [0; MAX_IPV4ADDRS],
         }
     }
+}
+
+impl IpAddrs<u32, MAX_IPV4ADDRS> for Ipv4Addrs {
+    #[inline(always)]
+    fn all(&self) -> bool {
+        self.addrs[0] == 0
+    }
 
     #[inline(always)]
-    pub fn all(&self) -> bool {
-        self.addrs[0] == 0
+    fn addrs(&self) -> [u32; MAX_IPV4ADDRS] {
+        self.addrs
     }
 }
 
@@ -230,10 +242,17 @@ impl Ipv6Addrs {
             addrs: [[0; 16]; MAX_IPV4ADDRS],
         }
     }
+}
+
+impl IpAddrs<[u8; 16], MAX_IPV6ADDRS> for Ipv6Addrs {
+    #[inline(always)]
+    fn all(&self) -> bool {
+        self.addrs[0] == [0; 16]
+    }
 
     #[inline(always)]
-    pub fn all(&self) -> bool {
-        self.addrs[0] == [0; 16]
+    fn addrs(&self) -> [[u8; 16]; MAX_IPV6ADDRS] {
+        self.addrs
     }
 }
 

--- a/guardity-ebpf/src/main.rs
+++ b/guardity-ebpf/src/main.rs
@@ -40,7 +40,7 @@ pub fn prog_socket_bind(ctx: LsmContext) -> i32 {
 #[lsm(name = "socket_connect")]
 pub fn prog_socket_connect(ctx: LsmContext) -> i32 {
     match socket_connect(ctx) {
-        Ok(ret) => ret,
+        Ok(ret) => ret.into(),
         Err(_) => 0,
     }
 }


### PR DESCRIPTION
Split it into multiple functions, make part of them generic, provide `IpAddrs` trait.