### PR TITLE
Send alerts through channels

### DIFF
--- a/guardity-common/src/lib.rs
+++ b/guardity-common/src/lib.rs
@@ -14,12 +14,34 @@ pub const MAX_IPV6ADDRS: usize = 1;
 pub trait Alert {}
 
 #[repr(C)]
-#[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "user", derive(Debug, serde::Serialize, serde::Deserialize))]
+#[derive(Copy, Clone)]
+pub struct AlertBprmCheckSecurity {
+    pub pid: u32,
+    #[cfg_attr(feature = "user", serde(skip))]
+    _padding: u32,
+    pub binprm_inode: u64,
+}
+
+impl AlertBprmCheckSecurity {
+    pub fn new(pid: u32, binprm_inode: u64) -> Self {
+        Self {
+            pid,
+            _padding: 0,
+            binprm_inode,
+        }
+    }
+}
+
+impl Alert for AlertBprmCheckSecurity {}
+
+#[repr(C)]
+#[cfg_attr(feature = "user", derive(Debug, serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
 pub struct AlertFileOpen {
     pub pid: u32,
     #[cfg_attr(feature = "user", serde(skip))]
-    pub _padding: u32,
+    _padding: u32,
     pub binprm_inode: u64,
     pub inode: u64,
 }
@@ -38,12 +60,12 @@ impl AlertFileOpen {
 impl Alert for AlertFileOpen {}
 
 #[repr(C)]
-#[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "user", derive(Debug, serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
 pub struct AlertSetuid {
     pub pid: u32,
     #[cfg_attr(feature = "user", serde(skip))]
-    pub _padding: u32,
+    _padding: u32,
     pub binprm_inode: u64,
     pub old_uid: u32,
     pub old_gid: u32,
@@ -75,16 +97,16 @@ impl AlertSetuid {
 impl Alert for AlertSetuid {}
 
 #[repr(C)]
-#[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "user", derive(Debug, serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
 pub struct AlertSocketBind {
     pub pid: u32,
     #[cfg_attr(feature = "user", serde(skip))]
-    pub _padding1: u32,
+    _padding1: u32,
     pub binprm_inode: u64,
     pub port: u16,
     #[cfg_attr(feature = "user", serde(skip))]
-    pub _padding2: [u16; 3],
+    _padding2: [u16; 3],
 }
 
 impl AlertSocketBind {
@@ -118,17 +140,17 @@ where
 }
 
 #[repr(C)]
-#[cfg_attr(feature = "user", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "user", derive(Debug, serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone)]
 pub struct AlertSocketConnect {
     pub pid: u32,
     #[cfg_attr(feature = "user", serde(skip))]
-    pub _padding1: u32,
+    _padding1: u32,
     pub binprm_inode: u64,
     #[cfg_attr(feature = "user", serde(serialize_with = "serialize_ipv4"))]
     pub addr_v4: u32,
     #[cfg_attr(feature = "user", serde(skip))]
-    pub _padding2: u32,
+    _padding2: u32,
     #[cfg_attr(feature = "user", serde(serialize_with = "serialize_ipv6"))]
     pub addr_v6: [u8; 16],
 }
@@ -162,21 +184,17 @@ impl Alert for AlertSocketConnect {}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Paths {
-    // pub all: bool,
-    // pub _padding: [u8; 7],
-    // pub len: usize,
     pub paths: [u64; MAX_PATHS],
-    // pub all: u64,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Ports {
     pub all: bool,
-    pub _padding1: [u8; 7],
+    _padding1: [u8; 7],
     pub len: usize,
     pub ports: [u16; MAX_PORTS],
-    pub _padding2: [u16; 3 * MAX_PORTS],
+    _padding2: [u16; 3 * MAX_PORTS],
 }
 
 impl Ports {

--- a/guardity-ebpf/src/bprm_check_security.rs
+++ b/guardity-ebpf/src/bprm_check_security.rs
@@ -1,12 +1,20 @@
-use aya_bpf::{cty::c_long, programs::LsmContext};
+use aya_bpf::{cty::c_long, programs::LsmContext, BpfContext};
+use guardity_common::AlertBprmCheckSecurity;
 
-use crate::vmlinux::linux_binprm;
+use crate::{binprm::current_binprm_inode, maps::ALERT_BPRM_CHECK_SECURITY, vmlinux::linux_binprm};
 
 pub fn bprm_check_security(ctx: LsmContext) -> Result<i32, c_long> {
-    let binprm: *const linux_binprm = unsafe { ctx.arg(0) };
-    let argc = unsafe { (*binprm).argc };
+    let new_binprm: *const linux_binprm = unsafe { ctx.arg(0) };
+    let argc = unsafe { (*new_binprm).argc };
+
+    let old_binprm_inode = current_binprm_inode();
 
     if argc < 1 {
+        ALERT_BPRM_CHECK_SECURITY.output(
+            &ctx,
+            &AlertBprmCheckSecurity::new(ctx.pid() as u32, old_binprm_inode),
+            0,
+        );
         return Ok(-1);
     }
 

--- a/guardity-ebpf/src/maps.rs
+++ b/guardity-ebpf/src/maps.rs
@@ -3,9 +3,13 @@ use aya_bpf::{
     maps::{HashMap, PerfEventArray},
 };
 use guardity_common::{
-    AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnect, Ipv4Addrs, Ipv6Addrs, Paths,
-    Ports,
+    AlertBprmCheckSecurity, AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnect,
+    Ipv4Addrs, Ipv6Addrs, Paths, Ports,
 };
+
+#[map]
+pub static ALERT_BPRM_CHECK_SECURITY: PerfEventArray<AlertBprmCheckSecurity> =
+    PerfEventArray::pinned(1024, 0);
 
 /// Map of allowed file open paths for each binary.
 #[map]
@@ -41,8 +45,7 @@ pub static DENIED_SOCKET_BIND: HashMap<u64, Ports> = HashMap::pinned(1024, 0);
 
 /// Map of alerts for `socket_bind` LSM hook inspection.
 #[map]
-pub static ALERT_SOCKET_BIND: PerfEventArray<AlertSocketBind> =
-    PerfEventArray::pinned(1024, 0);
+pub static ALERT_SOCKET_BIND: PerfEventArray<AlertSocketBind> = PerfEventArray::pinned(1024, 0);
 
 /// Map of allowed socket connect IPv4 addresses for each binary.
 #[map]

--- a/guardity/Cargo.toml
+++ b/guardity/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
 thiserror = "1.0"
 
 [[bin]]

--- a/guardity/src/lib.rs
+++ b/guardity/src/lib.rs
@@ -1,24 +1,32 @@
-use std::path::Path;
+use std::{fmt::Debug, marker::PhantomData, path::Path};
 
 use aya::{
     include_bytes_aligned,
+    maps::{AsyncPerfEventArray, MapData},
     programs::{lsm::LsmLink, Lsm},
+    util::online_cpus,
     Bpf, BpfLoader, Btf,
+};
+use bytes::BytesMut;
+use guardity_common::{
+    Alert, AlertBprmCheckSecurity, AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnect,
+};
+use tokio::{
+    sync::mpsc::{self, Receiver},
+    task,
 };
 
 pub mod fs;
 pub mod policy;
 
 pub struct PolicyManager {
-    pub bpf: Bpf,
-    pub bprm_check_security: Option<Hook>,
-    pub file_open: Option<Hook>,
-    pub setuid: Option<Hook>,
-    pub socket_bind: Option<Hook>,
-    pub socket_connect: Option<Hook>,
+    bpf: Bpf,
+    bprm_check_security: Option<BprmCheckSecurityHook>,
+    file_open: Option<FileOpenHook>,
+    task_fix_setuid: Option<TaskFixSetuidHook>,
+    socket_bind: Option<SocketBindHook>,
+    socket_connect: Option<SocketConnectHook>,
 }
-
-pub type Foo = Option<u32>;
 
 impl PolicyManager {
     pub fn new<P: AsRef<Path>>(bpf_path: P) -> anyhow::Result<Self> {
@@ -39,7 +47,7 @@ impl PolicyManager {
             bpf,
             bprm_check_security: None,
             file_open: None,
-            setuid: None,
+            task_fix_setuid: None,
             socket_bind: None,
             socket_connect: None,
         })
@@ -47,21 +55,30 @@ impl PolicyManager {
 
     pub fn attach_bprm_check_security(&mut self) -> anyhow::Result<()> {
         let link = attach_program(&mut self.bpf, "bprm_check_security")?;
-        let bprm_check_security = Hook::new(link)?;
+        let perf_array = perf_array(&mut self.bpf, "ALERT_BPRM_CHECK_SECURITY")?;
+        let bprm_check_security = Hook::new(link, perf_array)?;
         self.bprm_check_security = Some(bprm_check_security);
 
         Ok(())
     }
 
+    pub fn bprm_check_security(&mut self) -> anyhow::Result<&mut BprmCheckSecurityHook> {
+        match self.bprm_check_security {
+            Some(ref mut bprm_check_security) => Ok(bprm_check_security),
+            None => Err(anyhow::anyhow!("bprm_check_security is not attached")),
+        }
+    }
+
     pub fn attach_file_open(&mut self) -> anyhow::Result<()> {
         let link = attach_program(&mut self.bpf, "file_open")?;
-        let file_open = Hook::new(link)?;
+        let perf_array = perf_array(&mut self.bpf, "ALERT_FILE_OPEN")?;
+        let file_open = Hook::new(link, perf_array)?;
         self.file_open = Some(file_open);
 
         Ok(())
     }
 
-    pub fn file_open(&mut self) -> anyhow::Result<&mut Hook> {
+    pub fn file_open(&mut self) -> anyhow::Result<&mut FileOpenHook> {
         match self.file_open {
             Some(ref mut file_open) => Ok(file_open),
             None => Err(anyhow::anyhow!("file_open is not attached")),
@@ -70,14 +87,15 @@ impl PolicyManager {
 
     pub fn attach_task_fix_setuid(&mut self) -> anyhow::Result<()> {
         let link = attach_program(&mut self.bpf, "task_fix_setuid")?;
-        let setuid = Hook::new(link)?;
-        self.setuid = Some(setuid);
+        let perf_array = perf_array(&mut self.bpf, "ALERT_SETUID")?;
+        let setuid = Hook::new(link, perf_array)?;
+        self.task_fix_setuid = Some(setuid);
 
         Ok(())
     }
 
-    pub fn setuid(&mut self) -> anyhow::Result<&mut Hook> {
-        match self.setuid {
+    pub fn task_fix_setuid(&mut self) -> anyhow::Result<&mut TaskFixSetuidHook> {
+        match self.task_fix_setuid {
             Some(ref mut setuid) => Ok(setuid),
             None => Err(anyhow::anyhow!("setuid is not attached")),
         }
@@ -85,13 +103,14 @@ impl PolicyManager {
 
     pub fn attach_socket_bind(&mut self) -> anyhow::Result<()> {
         let link = attach_program(&mut self.bpf, "socket_bind")?;
-        let socket_bind = Hook::new(link)?;
+        let perf_array = perf_array(&mut self.bpf, "ALERT_SOCKET_BIND")?;
+        let socket_bind = Hook::new(link, perf_array)?;
         self.socket_bind = Some(socket_bind);
 
         Ok(())
     }
 
-    pub fn socket_bind(&mut self) -> anyhow::Result<&mut Hook> {
+    pub fn socket_bind(&mut self) -> anyhow::Result<&mut SocketBindHook> {
         match self.socket_bind {
             Some(ref mut socket_bind) => Ok(socket_bind),
             None => Err(anyhow::anyhow!("socket_bind is not attached")),
@@ -100,13 +119,14 @@ impl PolicyManager {
 
     pub fn attach_socket_connect(&mut self) -> anyhow::Result<()> {
         let link = attach_program(&mut self.bpf, "socket_connect")?;
-        let socket_connect = Hook::new(link)?;
+        let perf_array = perf_array(&mut self.bpf, "ALERT_SOCKET_CONNECT")?;
+        let socket_connect = Hook::new(link, perf_array)?;
         self.socket_connect = Some(socket_connect);
 
         Ok(())
     }
 
-    pub fn socket_connect(&mut self) -> anyhow::Result<&mut Hook> {
+    pub fn socket_connect(&mut self) -> anyhow::Result<&mut SocketConnectHook> {
         match self.socket_connect {
             Some(ref mut socket_connect) => Ok(socket_connect),
             None => Err(anyhow::anyhow!("socket_connect is not attached")),
@@ -124,13 +144,67 @@ fn attach_program(bpf: &mut Bpf, name: &str) -> anyhow::Result<LsmLink> {
     Ok(link)
 }
 
-pub struct Hook {
-    #[allow(dead_code)]
-    program_link: LsmLink,
+fn perf_array(bpf: &mut Bpf, name: &str) -> anyhow::Result<AsyncPerfEventArray<MapData>> {
+    let perf_array = bpf.take_map(name).unwrap().try_into()?;
+    Ok(perf_array)
 }
 
-impl Hook {
-    pub fn new(program_link: LsmLink) -> anyhow::Result<Self> {
-        Ok(Self { program_link })
+pub struct Hook<T>
+where
+    T: Alert,
+{
+    #[allow(dead_code)]
+    program_link: LsmLink,
+    perf_array: AsyncPerfEventArray<MapData>,
+    phantom: PhantomData<T>,
+}
+
+impl<T> Hook<T>
+where
+    T: Alert + Debug + Send + 'static,
+{
+    fn new(
+        program_link: LsmLink,
+        perf_array: AsyncPerfEventArray<MapData>,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            program_link,
+            perf_array,
+            phantom: PhantomData,
+        })
+    }
+
+    pub async fn alerts(&mut self) -> anyhow::Result<Receiver<T>> {
+        let (tx, rx) = mpsc::channel(32);
+
+        let cpus = online_cpus()?;
+        for cpu_id in cpus {
+            let tx = tx.clone();
+            let mut buf = self.perf_array.open(cpu_id, None)?;
+
+            task::spawn(async move {
+                let mut buffers = (0..10)
+                    .map(|_| BytesMut::with_capacity(1024))
+                    .collect::<Vec<_>>();
+                loop {
+                    let events = buf.read_events(&mut buffers).await.unwrap();
+                    for buf in buffers.iter_mut().take(events.read) {
+                        let alert = {
+                            let ptr = buf.as_ptr() as *const T;
+                            unsafe { ptr.read_unaligned() }
+                        };
+                        tx.send(alert).await.unwrap();
+                    }
+                }
+            });
+        }
+
+        Ok(rx)
     }
 }
+
+pub type BprmCheckSecurityHook = Hook<AlertBprmCheckSecurity>;
+pub type FileOpenHook = Hook<AlertFileOpen>;
+pub type TaskFixSetuidHook = Hook<AlertSetuid>;
+pub type SocketBindHook = Hook<AlertSocketBind>;
+pub type SocketConnectHook = Hook<AlertSocketConnect>;

--- a/guardity/src/main.rs
+++ b/guardity/src/main.rs
@@ -1,14 +1,9 @@
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 
-use aya::maps::{AsyncPerfEventArray, MapData};
-use aya::util::online_cpus;
-use bytes::BytesMut;
 use clap::Parser;
 use guardity::PolicyManager;
-use guardity_common::{AlertFileOpen, AlertSetuid, AlertSocketBind, AlertSocketConnect};
 use log::info;
-use serde::Serialize;
 use tokio::signal;
 
 #[derive(Debug, Parser)]
@@ -21,86 +16,68 @@ struct Opt {
     policy: Vec<PathBuf>,
 }
 
-async fn read_alerts<T>(mut map: AsyncPerfEventArray<MapData>)
-where
-    T: Serialize + Send + Sync + 'static,
-{
-    let cpus = online_cpus().unwrap();
-    for cpu_id in cpus {
-        let mut buf = map.open(cpu_id, None).unwrap();
-
-        tokio::spawn(async move {
-            let mut buffers = (0..10)
-                .map(|_| BytesMut::with_capacity(1024))
-                .collect::<Vec<_>>();
-
-            loop {
-                let events = buf.read_events(&mut buffers).await.unwrap();
-                for buf in buffers.iter_mut().take(events.read) {
-                    let ptr = buf.as_ptr() as *const T;
-                    let data = unsafe { ptr.read_unaligned() };
-                    eprintln!("{}", serde_json::to_string(&data).unwrap());
-                }
-            }
-        });
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let opt = Opt::parse();
 
     env_logger::init();
 
-    // This will include your eBPF object file as raw bytes at compile-time and load it at
-    // runtime. This approach is recommended for most real-world use cases. If you would
-    // like to specify the eBPF program at runtime rather than at compile-time, you can
-    // reach for `Bpf::load_file` instead.
     let bpf_path = opt.bpffs_path.join(opt.bpffs_dir);
     create_dir_all(&bpf_path)?;
 
     let mut policy_manager = PolicyManager::new(bpf_path)?;
+
     policy_manager.attach_bprm_check_security()?;
     policy_manager.attach_file_open()?;
     policy_manager.attach_task_fix_setuid()?;
     policy_manager.attach_socket_bind()?;
     policy_manager.attach_socket_connect()?;
 
-    read_alerts::<AlertFileOpen>(
-        policy_manager
-            .bpf
-            .take_map("ALERT_FILE_OPEN")
-            .unwrap()
-            .try_into()?,
-    )
-    .await;
-    read_alerts::<AlertSetuid>(
-        policy_manager
-            .bpf
-            .take_map("ALERT_SETUID")
-            .unwrap()
-            .try_into()?,
-    )
-    .await;
-    read_alerts::<AlertSocketBind>(
-        policy_manager
-            .bpf
-            .take_map("ALERT_SOCKET_BIND")
-            .unwrap()
-            .try_into()?,
-    )
-    .await;
-    read_alerts::<AlertSocketConnect>(
-        policy_manager
-            .bpf
-            .take_map("ALERT_SOCKET_CONNECT")
-            .unwrap()
-            .try_into()?,
-    )
-    .await;
+    let mut rx_bprm_check_security = policy_manager.bprm_check_security()?.alerts().await?;
+    let mut rx_file_open = policy_manager.file_open()?.alerts().await?;
+    let mut rx_task_fix_setuid = policy_manager.task_fix_setuid()?.alerts().await?;
+    let mut rx_socket_bind = policy_manager.socket_bind()?.alerts().await?;
+    let mut rx_socket_connect = policy_manager.socket_connect()?.alerts().await?;
 
     info!("Waiting for Ctrl-C...");
-    signal::ctrl_c().await?;
+
+    loop {
+        tokio::select! {
+            Some(alert) = rx_bprm_check_security.recv() => {
+                info!("bprm_check_security: {}", alert.pid);
+            }
+            Some(alert) = rx_file_open.recv() => {
+                info!("file_open: {}", alert.pid);
+            }
+            Some(alert) = rx_task_fix_setuid.recv() => {
+                info!("task_fix_setuid: pid={} binprm_inode={}", alert.pid, alert.binprm_inode);
+            }
+            Some(alert) = rx_socket_bind.recv() => {
+                info!("socket_bind: pid={}", alert.pid);
+            }
+            Some(alert) = rx_socket_connect.recv() => {
+                if alert.addr_v4 != 0 {
+                    info!(
+                        "socket_connect: pid={} binprm_inode={} addr={}",
+                        alert.pid,
+                        alert.binprm_inode,
+                        alert.addr_v4
+                    );
+                } else {
+                    info!(
+                        "socket_connect: pid={} binprm_inode={} addr={:?}",
+                        alert.pid,
+                        alert.binprm_inode,
+                        alert.addr_v6
+                    );
+                }
+            }
+            _ = signal::ctrl_c() => {
+                break;
+            }
+        }
+    }
+
     info!("Exiting...");
 
     Ok(())


### PR DESCRIPTION
Requiring users to deal with `AsyncPerfEventArray` and read events manually is not the best API. It's better to expose alerts with `mpsc` channels.