### PR TITLE
guardity: Use `thiserror` instead of `anyhow`

### DIFF
--- a/guardity/Cargo.toml
+++ b/guardity/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
 aya = { git = "https://github.com/aya-rs/aya", branch = "main", features=["async_tokio"] }
 bytes = "1.4"
 clap = { version = "4.2", features = ["derive"] }

--- a/guardity/src/error.rs
+++ b/guardity/src/error.rs
@@ -2,6 +2,24 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum GuardityError {
-    #[error("Failed to find an inode for the given path")]
-    Inode(#[from] std::io::Error),
+    #[error("Failed to load BPF program: {0}")]
+    Bpf(#[from] aya::BpfError),
+
+    #[error("Failed to get BTF info from the system: {0}")]
+    Btf(#[from] aya::BtfError),
+
+    #[error("Failed to load BPF program: {0}")]
+    BpfProgramError(#[from] aya::programs::ProgramError),
+
+    #[error("I/O error: {0}")]
+    IO(#[from] std::io::Error),
+
+    #[error("Map error: {0}")]
+    Map(#[from] aya::maps::MapError),
+
+    #[error("Failed to open a perf buffer: {0}")]
+    PerfBuffer(#[from] aya::maps::perf::PerfBufferError),
+
+    #[error("Failed to parse policies from YAML: {0}")]
+    YAML(#[from] serde_yaml::Error),
 }

--- a/guardity/src/policy/inode.rs
+++ b/guardity/src/policy/inode.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::fs;
+use crate::{error::GuardityError, fs};
 
 use super::PolicySubject;
 
@@ -10,7 +10,7 @@ pub struct InodeSubjectMap {
 }
 
 impl InodeSubjectMap {
-    pub fn resolve_path(&mut self, subject: PolicySubject) -> anyhow::Result<u64> {
+    pub fn resolve_path(&mut self, subject: PolicySubject) -> Result<u64, GuardityError> {
         match subject {
             PolicySubject::Binary(path) => {
                 let inode = fs::inode(&path)?;

--- a/guardity/src/policy/reader.rs
+++ b/guardity/src/policy/reader.rs
@@ -1,8 +1,10 @@
 use std::{fs, path::Path};
 
+use crate::error::GuardityError;
+
 use super::Policy;
 
-pub fn read_policies<P: AsRef<Path>>(path: P) -> anyhow::Result<Vec<Policy>> {
+pub fn read_policies<P: AsRef<Path>>(path: P) -> Result<Vec<Policy>, GuardityError> {
     let path = path.as_ref();
     let yaml = fs::read_to_string(path)?;
     let policies = serde_yaml::from_str::<Vec<Policy>>(&yaml)?;


### PR DESCRIPTION
The unwritten rule in Rust is to use `thiserror` for library code (where errors need to be distinguished) and `anyhow` in binary code (where we just want to handle any errors that libraries return). Let's stick to it.