### PR TITLE
ebpf: Use `bpf_get_current_task` instead of `bpf_get_current_task_btf`

### DIFF
--- a/ebpfguard-ebpf/src/binprm.rs
+++ b/ebpfguard-ebpf/src/binprm.rs
@@ -1,4 +1,7 @@
-use aya_bpf::helpers::bpf_get_current_task_btf;
+use aya_bpf::{
+    cty::c_long,
+    helpers::{bpf_get_current_task, bpf_probe_read_kernel},
+};
 
 use crate::vmlinux::task_struct;
 
@@ -9,10 +12,19 @@ use crate::vmlinux::task_struct;
 /// ```rust
 /// use ebpfguard_ebpf::binprm::current_binprm_inode;
 ///
-/// let inode = current_binprm_inode();
+/// # fn main() -> Result<(), c_long> {
+/// let inode = current_binprm_inode()?;
+/// # Ok(())
+/// # }
 /// ```
 #[inline(always)]
-pub(crate) fn current_binprm_inode() -> u64 {
-    let task = unsafe { bpf_get_current_task_btf() as *mut task_struct };
-    unsafe { (*(*(*(*task).mm).__bindgen_anon_1.exe_file).f_inode).i_ino }
+pub(crate) fn current_binprm_inode() -> Result<u64, c_long> {
+    let binprm_inode = unsafe {
+        let task = bpf_get_current_task() as *mut task_struct;
+        let mm = bpf_probe_read_kernel(&(*task).mm)?;
+        let file = bpf_probe_read_kernel(&(*mm).__bindgen_anon_1.exe_file)?;
+        let f_inode = bpf_probe_read_kernel(&(*file).f_inode)?;
+        bpf_probe_read_kernel(&(*f_inode).i_ino)?
+    };
+    Ok(binprm_inode)
 }

--- a/ebpfguard-ebpf/src/bprm_check_security.rs
+++ b/ebpfguard-ebpf/src/bprm_check_security.rs
@@ -7,7 +7,7 @@ pub fn bprm_check_security(ctx: LsmContext) -> Result<i32, c_long> {
     let new_binprm: *const linux_binprm = unsafe { ctx.arg(0) };
     let argc = unsafe { (*new_binprm).argc };
 
-    let old_binprm_inode = current_binprm_inode();
+    let old_binprm_inode = current_binprm_inode()?;
 
     if argc < 1 {
         ALERT_BPRM_CHECK_SECURITY.output(

--- a/ebpfguard-ebpf/src/main.rs
+++ b/ebpfguard-ebpf/src/main.rs
@@ -19,7 +19,10 @@ pub fn prog_bprm_check_security(ctx: LsmContext) -> i32 {
 
 #[lsm(name = "file_open")]
 pub fn prog_file_open(ctx: LsmContext) -> i32 {
-    file_open(ctx).into()
+    match file_open(ctx) {
+        Ok(ret) => ret.into(),
+        Err(_) => 0,
+    }
 }
 
 #[lsm(name = "task_fix_setuid")]
@@ -32,22 +35,34 @@ pub fn prog_task_fix_setuid(ctx: LsmContext) -> i32 {
 
 #[lsm(name = "sb_mount")]
 pub fn prog_sb_mount(ctx: LsmContext) -> i32 {
-    sb_mount(ctx).into()
+    match sb_mount(ctx) {
+        Ok(ret) => ret.into(),
+        Err(_) => 0,
+    }
 }
 
 #[lsm(name = "sb_remount")]
 pub fn prog_sb_remount(ctx: LsmContext) -> i32 {
-    sb_remount(ctx).into()
+    match sb_remount(ctx) {
+        Ok(ret) => ret.into(),
+        Err(_) => 0,
+    }
 }
 
 #[lsm(name = "sb_umount")]
 pub fn prog_sb_umount(ctx: LsmContext) -> i32 {
-    sb_umount(ctx).into()
+    match sb_umount(ctx) {
+        Ok(ret) => ret.into(),
+        Err(_) => 0,
+    }
 }
 
 #[lsm(name = "socket_bind")]
 pub fn prog_socket_bind(ctx: LsmContext) -> i32 {
-    socket_bind(ctx).into()
+    match socket_bind(ctx) {
+        Ok(ret) => ret.into(),
+        Err(_) => 0,
+    }
 }
 
 #[lsm(name = "socket_connect")]

--- a/ebpfguard-ebpf/src/sb_mount.rs
+++ b/ebpfguard-ebpf/src/sb_mount.rs
@@ -1,4 +1,4 @@
-use aya_bpf::{maps::HashMap, programs::LsmContext, BpfContext};
+use aya_bpf::{maps::HashMap, programs::LsmContext, BpfContext, cty::c_long};
 use ebpfguard_common::{alerts, consts::INODE_WILDCARD};
 
 use crate::{
@@ -23,18 +23,18 @@ use crate::{
 ///     sb_mount(ctx).into()
 /// }
 /// ```
-pub fn sb_mount(ctx: LsmContext) -> Action {
-    let binprm_inode = current_binprm_inode();
+pub fn sb_mount(ctx: LsmContext) -> Result<Action, c_long> {
+    let binprm_inode = current_binprm_inode()?;
 
     if unsafe { ALLOWED_SB_MOUNT.get(&INODE_WILDCARD).is_some() } {
-        return check_conditions_and_alert(&ctx, &DENIED_SB_MOUNT, binprm_inode, Mode::Denylist);
+        return Ok(check_conditions_and_alert(&ctx, &DENIED_SB_MOUNT, binprm_inode, Mode::Denylist));
     }
 
     if unsafe { DENIED_SB_MOUNT.get(&INODE_WILDCARD).is_some() } {
-        return check_conditions_and_alert(&ctx, &ALLOWED_SB_MOUNT, binprm_inode, Mode::Allowlist);
+        return Ok(check_conditions_and_alert(&ctx, &ALLOWED_SB_MOUNT, binprm_inode, Mode::Allowlist));
     }
 
-    Action::Allow
+    Ok(Action::Allow)
 }
 
 #[inline(always)]

--- a/ebpfguard-ebpf/src/sb_umount.rs
+++ b/ebpfguard-ebpf/src/sb_umount.rs
@@ -1,4 +1,4 @@
-use aya_bpf::{maps::HashMap, programs::LsmContext, BpfContext};
+use aya_bpf::{cty::c_long, maps::HashMap, programs::LsmContext, BpfContext};
 use ebpfguard_common::{alerts, consts::INODE_WILDCARD};
 
 use crate::{
@@ -23,18 +23,28 @@ use crate::{
 ///     sb_umount(ctx).into()
 /// }
 /// ```
-pub fn sb_umount(ctx: LsmContext) -> Action {
-    let binprm_inode = current_binprm_inode();
+pub fn sb_umount(ctx: LsmContext) -> Result<Action, c_long> {
+    let binprm_inode = current_binprm_inode()?;
 
     if unsafe { ALLOWED_SB_UMOUNT.get(&INODE_WILDCARD).is_some() } {
-        return check_conditions_and_alert(&ctx, &DENIED_SB_UMOUNT, binprm_inode, Mode::Denylist);
+        return Ok(check_conditions_and_alert(
+            &ctx,
+            &DENIED_SB_UMOUNT,
+            binprm_inode,
+            Mode::Denylist,
+        ));
     }
 
     if unsafe { DENIED_SB_UMOUNT.get(&INODE_WILDCARD).is_some() } {
-        return check_conditions_and_alert(&ctx, &ALLOWED_SB_UMOUNT, binprm_inode, Mode::Allowlist);
+        return Ok(check_conditions_and_alert(
+            &ctx,
+            &ALLOWED_SB_UMOUNT,
+            binprm_inode,
+            Mode::Allowlist,
+        ));
     }
 
-    Action::Allow
+    Ok(Action::Allow)
 }
 
 #[inline(always)]

--- a/ebpfguard-ebpf/src/socket_connect.rs
+++ b/ebpfguard-ebpf/src/socket_connect.rs
@@ -53,7 +53,7 @@ fn socket_connect_v4(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<Actio
     let sockaddr_in: *const sockaddr_in = sockaddr as *const sockaddr_in;
     let addr = u32::from_be(unsafe { (*sockaddr_in).sin_addr.s_addr });
 
-    let binprm_inode = current_binprm_inode();
+    let binprm_inode = current_binprm_inode()?;
 
     if let Some(addrs) = unsafe { ALLOWED_SOCKET_CONNECT_V4.get(&INODE_WILDCARD) } {
         if addrs.all() {
@@ -89,7 +89,7 @@ fn socket_connect_v6(ctx: LsmContext, sockaddr: *const sockaddr) -> Result<Actio
     let sockaddr_in6: sockaddr_in6 = unsafe { bpf_probe_read_kernel(sockaddr_in6)? };
     let addr = unsafe { sockaddr_in6.sin6_addr.in6_u.u6_addr8 };
 
-    let binprm_inode = current_binprm_inode();
+    let binprm_inode = current_binprm_inode()?;
 
     if let Some(addrs) = unsafe { ALLOWED_SOCKET_CONNECT_V6.get(&INODE_WILDCARD) } {
         if addrs.all() {

--- a/ebpfguard-ebpf/src/task_fix_setuid.rs
+++ b/ebpfguard-ebpf/src/task_fix_setuid.rs
@@ -35,7 +35,7 @@ pub fn task_fix_setuid(ctx: LsmContext) -> Result<i32, c_long> {
     let new_uid = unsafe { (*new).uid.val };
     let new_gid = unsafe { (*new).gid.val };
 
-    let binprm_inode = current_binprm_inode();
+    let binprm_inode = current_binprm_inode()?;
 
     if unsafe { ALLOWED_TASK_FIX_SETUID.get(&INODE_WILDCARD) }.is_some() {
         if unsafe { DENIED_TASK_FIX_SETUID.get(&binprm_inode).is_some() } {


### PR DESCRIPTION
The latter was introduced in kernel 5.15, the previous one should be available on older kernels.

Fixes: https://github.com/deepfence/ebpfguard/pull/38