### PR TITLE
CI: replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt, clippy, miri, rust-src
 
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt, clippy


### PR DESCRIPTION
Former is no longer supported. See https://github.com/actions-rs/toolchain/issues/216.