### PR TITLE
BTF: adjust environment for correct linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,17 +20,19 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+          targets: x86_64-unknown-linux-musl
           components: rustfmt, clippy, miri, rust-src
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+          targets: x86_64-unknown-linux-musl
           components: rustfmt, clippy
 
       - name: Install bpf-linker
         run: |
-          cargo install bpf-linker
+          cargo install bpf-linker --git https://github.com/noboruma/bpf-linker
 
       - name: Build eBPF code
         run: |

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl https://sh.rustup.rs --proto '=https' --tlsv1.2 -sSf | sh -s -- -y
 RUN $HOME/.cargo/bin/rustup toolchain install nightly --component rust-src
 RUN $HOME/.cargo/bin/rustup component add miri --toolchain nightly
-RUN $HOME/.cargo/bin/cargo install bpf-linker bindgen-cli
+RUN $HOME/.cargo/bin/cargo install bpf-linker --git https://github.com/noboruma/bpf-linker
+RUN $HOME/.cargo/bin/cargo install bindgen-cli

--- a/docs/gh/prerequisites.md
+++ b/docs/gh/prerequisites.md
@@ -138,7 +138,7 @@ $ cargo install bindgen-cli
 Install bpf-linker:
 
 ```
-$ cargo install bpf-linker
+$ cargo install bpf-linker --git https://github.com/noboruma/bpf-linker
 ```
 
 bpf-linker installation on architectures other than x86_64 may be more involved. Refer to [aya-rs documentation](https://aya-rs.dev/book/start/development/) for instructions.

--- a/ebpfguard-ebpf/build.rs
+++ b/ebpfguard-ebpf/build.rs
@@ -24,11 +24,12 @@ fn main() {
     ];
 
     let bindings = aya_tool::generate(
-        InputFile::Btf(PathBuf::from("/sys/kernel/btf/vmlinux")),
+        InputFile::Header(PathBuf::from("src/vmlinux.h")),
         &names,
         &[],
     )
     .unwrap();
+    println!("cargo:rerun-if-changed=src/src/vmlinux.h");
 
     let mut out = File::create(dest_path).unwrap();
     write!(out, "{}", bindings).unwrap();


### PR DESCRIPTION
- changed lib build target to `x86_64-unknown-linux-musl` so we don't have libc incompatibilities
- changed all envs and examples to point to `bpf-linker` with Thomas changes
- changed ebpfguard-ebpf build.rs to use `vmlinux.h` checked into repository, added rebuild if changed directive for that file