### PR TITLE
Dev: enable inclusion of ebpfguard as a regular cargo dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "xtask",
     "examples/*",
 ]
+exclude = ["ebpfguard-ebpf"]
 
 [patch.crates-io]
 aya = { git = "https://github.com/deepfence/aya-rs", branch = "btf-fixes" }

--- a/ebpfguard-common/Cargo.toml
+++ b/ebpfguard-common/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 user = ["aya"]
 
 [dependencies]
-aya = { version = ">=0.11", optional = true }
+aya = { git = "https://github.com/deepfence/aya-rs", branch = "btf-fixes", optional=true }
 
 [lib]
 path = "src/lib.rs"

--- a/ebpfguard/src/lib.rs
+++ b/ebpfguard/src/lib.rs
@@ -230,7 +230,7 @@ pub struct PolicyManager {
 
 impl PolicyManager {
     /// Default path for storage of eBPFGuard maps
-    const DEFAULT_BPFFS_MAPS_PATH: &str = "/sys/fs/bpf/ebpfguard_default";
+    pub const DEFAULT_BPFFS_MAPS_PATH: &str = "/sys/fs/bpf/ebpfguard_default";
 
     /// Creates a new policy manager with default maps path.
     ///
@@ -242,6 +242,7 @@ impl PolicyManager {
     /// let mut policy_manager = PolicyManager::with_default_path().unwrap();
     /// ```
     pub fn with_default_path() -> Result<Self, EbpfguardError> {
+        std::fs::create_dir_all(Self::DEFAULT_BPFFS_MAPS_PATH)?;
         Self::new(Self::DEFAULT_BPFFS_MAPS_PATH)
     }
 
@@ -260,13 +261,13 @@ impl PolicyManager {
         let bpf = BpfLoader::new()
             .map_pin_path(&bpf_path)
             .load(include_bytes_aligned!(
-                "../../target/bpfel-unknown-none/debug/ebpfguard"
+                "../../ebpfguard-ebpf/ebpfguard.debug.obj"
             ))?;
         #[cfg(not(debug_assertions))]
         let bpf = BpfLoader::new()
             .map_pin_path(&bpf_path)
             .load(include_bytes_aligned!(
-                "../../target/bpfel-unknown-none/release/ebpfguard"
+                "../../ebpfguard-ebpf/ebpfguard.release.obj"
             ))?;
 
         Ok(Self { bpf })


### PR DESCRIPTION
This is a workaround for the need to invoke `cargo xtask build-ebpf` during library compilation. I don't see a way currently to seamlessly do that while user compiles ebpfguard as a dependency in their project. Hence we will just embed latest eBPF object file now that BTF support is merged.

automatic xtask invocation tracking issue -  https://github.com/deepfence/ebpfguard/issues/30.