### PR TITLE
Add debug flag to cargo release profile

### DIFF
--- a/ebpfguard-ebpf/Cargo.toml
+++ b/ebpfguard-ebpf/Cargo.toml
@@ -32,6 +32,7 @@ rpath = false
 lto = true
 panic = "abort"
 codegen-units = 1
+debug = 2
 
 [workspace]
 members = []


### PR DESCRIPTION
Prevents `bpf-linker` to segfault on `--release`

Closes https://github.com/deepfence/ebpfguard/issues/44