### PR TITLE
PolicyManager: fail instantiation if bpf lsm module is disabled

### DIFF
--- a/ebpfguard/src/error.rs
+++ b/ebpfguard/src/error.rs
@@ -2,6 +2,11 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum EbpfguardError {
+    #[error(
+        "BPF LSM module is not enabled. Check prerequisites doc for instructions how to enable it."
+    )]
+    BpfLsmModuleDisabled,
+
     #[error("Failed to load BPF program: {0}")]
     Bpf(#[from] aya::BpfError),
 

--- a/ebpfguard/src/lib.rs
+++ b/ebpfguard/src/lib.rs
@@ -257,6 +257,13 @@ impl PolicyManager {
     /// let mut policy_manager = PolicyManager::new(Path::new("/sys/fs/bpf/mypolicies")).unwrap();
     /// ```
     pub fn new<P: AsRef<Path>>(bpf_path: P) -> Result<Self, EbpfguardError> {
+        let bpf_lsm_enabled = std::fs::read_to_string("/sys/kernel/security/lsm")?
+            .split(',')
+            .any(|x| x.to_lowercase() == "bpf");
+        if !bpf_lsm_enabled {
+            return Err(EbpfguardError::BpfLsmModuleDisabled);
+        }
+
         #[cfg(debug_assertions)]
         let bpf = BpfLoader::new()
             .map_pin_path(&bpf_path)


### PR DESCRIPTION
To prevent further issues similar to https://github.com/deepfence/ebpfguard/issues/55 this PR adds runtime check during PolicyManager instantiation which verifies that bpf lsm module is enabled.

Sadly in current state kernel verifies and loads bpf bytecode and syscalls don't error out on such condition. User just sees hooks that don't enforce policies.